### PR TITLE
fix: make all dependencies required for runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,20 +11,17 @@
   "license": "MIT",
   "dependencies": {
     "ansi-regex": "^2.0.0",
+    "babel-core": "^6.5.2",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.5.2",
+    "babel-polyfill": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-stage-1": "^6.5.0",
     "bluebird": "^3.3.3",
     "colors": "^1.1.2",
     "inflection": "^1.8.0",
     "moment": "^2.11.2",
     "mysql": "^2.10.2",
     "sequelize": "^3.19.3"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.5.1",
-    "babel-core": "^6.5.2",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-runtime": "^6.5.2",
-    "babel-polyfill": "^6.5.0",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-preset-stage-1": "^6.5.0"
   }
 }


### PR DESCRIPTION
The way running an app with this framework will work will require babel and babel plugins during runtime rather than transpiling code to a dist dir.
