### PR TITLE
fix: shebang line not finding node on linux

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -1,2 +1,2 @@
-#!/usr/bin/env node --use_strict
+#!/usr/bin/env node
 require('../dist/packages/cli');

--- a/examples/social-network/package.json
+++ b/examples/social-network/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "lux-framework": "0.0.1-beta",
+    "lux-framework": "0.0.1-beta.1",
     "babel-core": "6.7.4",
     "babel-eslint": "6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "lux-framework": "0.0.1-beta",
+    "lux-framework": "0.0.1-beta.1",
     "babel-core": "6.7.4",
     "babel-eslint": "6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lux-framework",
-  "version": "0.0.1-beta",
+  "version": "0.0.1-beta.1",
   "description": "A MVC style Node.js framework for building lightning fast JSON APIs",
   "repository": "https://github.com/postlight/lux",
   "main": "dist/index.js",

--- a/src/packages/cli/index.js
+++ b/src/packages/cli/index.js
@@ -8,7 +8,7 @@ import generate from './commands/generate';
 
 import tryCatch from '../../utils/try-catch';
 
-cli.version('0.0.1-beta');
+cli.version('0.0.1-beta.1');
 
 cli
   .command('n <name>')

--- a/src/packages/cli/templates/package-json.js
+++ b/src/packages/cli/templates/package-json.js
@@ -12,7 +12,7 @@ export default (name) => {
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "lux-framework": "0.0.1-beta",
+    "lux-framework": "0.0.1-beta.1",
     "babel-core": "6.7.4",
     "babel-eslint": "6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",


### PR DESCRIPTION
This PR resolves an error where the `--use_strict` flag in the shebang line of `bin/lux` does not find `node` on linux.