### PR TITLE
fix: listening message dispatched before workers are ready

### DIFF
--- a/examples/social-network/package.json
+++ b/examples/social-network/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "lux-framework": "0.0.1-beta.1",
+    "lux-framework": "0.0.1-beta.2",
     "babel-core": "6.7.4",
     "babel-eslint": "6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "lux-framework": "0.0.1-beta.1",
+    "lux-framework": "0.0.1-beta.2",
     "babel-core": "6.7.4",
     "babel-eslint": "6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lux-framework",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "description": "A MVC style Node.js framework for building lightning fast JSON APIs",
   "repository": "https://github.com/postlight/lux",
   "main": "dist/index.js",

--- a/src/packages/application/index.js
+++ b/src/packages/application/index.js
@@ -28,7 +28,7 @@ class Application extends Base {
   }
 
   async boot() {
-    const { root, router, domain } = this;
+    const { root, router, domain, server, port } = this;
     const store = Database.create(
       require(`${root}/config/database.json`)
     );
@@ -133,7 +133,8 @@ class Application extends Base {
 
     routes.get('routes').call(null, router.route, router.resource);
 
-    this.server.listen(this.port);
+    server.instance.once('listening', () => process.send('ready'));
+    server.listen(port);
 
     return this;
   }

--- a/src/packages/cli/index.js
+++ b/src/packages/cli/index.js
@@ -8,7 +8,7 @@ import generate from './commands/generate';
 
 import tryCatch from '../../utils/try-catch';
 
-cli.version('0.0.1-beta.1');
+cli.version('0.0.1-beta.2');
 
 cli
   .command('n <name>')

--- a/src/packages/cli/templates/package-json.js
+++ b/src/packages/cli/templates/package-json.js
@@ -12,7 +12,7 @@ export default (name) => {
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "lux-framework": "0.0.1-beta.1",
+    "lux-framework": "0.0.1-beta.2",
     "babel-core": "6.7.4",
     "babel-eslint": "6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",


### PR DESCRIPTION
This PR fixes an issue where the `Lux Server listening on {port}` message is written to stdout before all worker processes are ready.

**Before:**

<img width="682" alt="screen shot 2016-04-18 at 9 14 48 am" src="https://cloud.githubusercontent.com/assets/7378772/14605307/0c1944e0-0546-11e6-876e-fc716fffbc79.png">

**After:**

<img width="682" alt="screen shot 2016-04-18 at 9 05 01 am" src="https://cloud.githubusercontent.com/assets/7378772/14605271/e308d232-0545-11e6-9c37-48555b775aa0.png">
