### PR TITLE
fix: logger date incorrect

### DIFF
--- a/src/packages/logger/index.js
+++ b/src/packages/logger/index.js
@@ -17,7 +17,7 @@ class Logger extends Base {
   }
 
   get timestamp() {
-    return moment().format('M/d/YY h:m:ss A');
+    return moment().format('M/D/YY h:m:ss A');
   }
 
   @bound


### PR DESCRIPTION
The logger is producing an incorrect date.

```
[4/1/16 2:55:25 PM] Starting Lux Server with 8 worker processes
```

Should be
```
[4/18/16 2:55:25 PM] Starting Lux Server with 8 worker processes
```