### PR TITLE
fix: make ora a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "commander": "2.9.0",
     "inflection": "1.9.0",
     "moment": "2.12.0",
+    "ora": "0.2.1",
     "orm": "2.1.30"
   },
   "devDependencies": {
@@ -35,7 +36,6 @@
     "gulp-babel": "6.1.2",
     "gulp-eslint": "2.0.0",
     "gulp-uglify": "1.5.3",
-    "mysql": "2.10.2",
-    "ora": "0.2.1"
+    "mysql": "2.10.2"
   }
 }


### PR DESCRIPTION
I missed this in #38. [Ora](https://github.com/sindresorhus/ora) should be a runtime dependency.