### PR TITLE
chore: test on node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "6"
   - "5"
 
 services:


### PR DESCRIPTION
Now that [Node 6 is out](https://nodejs.org/en/blog/announcements/v6-release/), we should run tests against it on Travis.