### PR TITLE
fix: HEAD and OPTIONS request result in a 404

### DIFF
--- a/src/packages/controller/index.js
+++ b/src/packages/controller/index.js
@@ -150,7 +150,9 @@ class Controller extends Base {
 
   @action
   preflight() {
-    return true;
+    return {
+      data: true
+    };
   }
 }
 

--- a/test/integration/controller.js
+++ b/test/integration/controller.js
@@ -451,4 +451,18 @@ describe('Integration: class Controller', () => {
       expect(subject.status).to.equal(204);
     });
   });
+
+  describe('#preflight()', () => {
+    let subject;
+
+    before(async () => {
+      subject = await fetch(`${host}/posts`, {
+        method: 'OPTIONS'
+      });
+    });
+
+    it('has 204 status code', () => {
+      expect(subject.status).to.equal(204);
+    });
+  });
 });


### PR DESCRIPTION
Currently the action decorator is [expecting an object](https://github.com/postlight/lux/blob/master/src/packages/controller/decorators/action.js#L16) with a data property as a response. In a future release we will refactor the decorator to evaluate the type of a resolved value of a route action before returning the value back to the Router.

For now, this enables `HEAD` and `OPTIONS` requests.

--
cc @jhliberty