### PR TITLE
feat: use local lux install if one exists

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -1,2 +1,6 @@
 #!/usr/bin/env node
-require('../dist/packages/cli');
+try {
+  require(`${process.env.PWD}/node_modules/lux-framework/dist/packages/cli`);
+} catch (err) {
+  require('../dist/packages/cli');
+}


### PR DESCRIPTION
This PR allows for the `lux` command to use the locally installed version of Lux if one exists, otherwise the globally installed version of Lux will be used.

**Benefits:**
- Users can work on multiple Lux projects that all use different versions seamlessly
- Upgrading Lux can be done without having to `npm uninstall -g lux-framework; npm install -g lux-framework`