### PR TITLE
test: add correct g++ version for node 4+ in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_script:
   - npm link
 
 env:
-  - CXX=g++-4.8
-  - NODE_ENV="test"
+  global:
+    - CXX=g++-4.8
+    - NODE_ENV=test
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,13 @@ before_script:
   - npm link
 
 env:
+  - CXX=g++-4.8
   - NODE_ENV="test"
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: true
+
 language: node_js
 
 node_js:


### PR DESCRIPTION
Gets rid of the following [warning](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements) on Travis-CI:

> Starting with io.js 3 and Node.js 4, building native extensions requires C++11-compatible compiler, which seems unavailable on this VM. Please read https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements.