### PR TITLE
refactor: use chalk instead of colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ansi-regex": "2.0.0",
     "babel-runtime": "6.9.0",
     "bluebird": "3.3.5",
-    "colors": "1.1.2",
+    "chalk": "1.1.3",
     "commander": "2.9.0",
     "inflection": "1.10.0",
     "moment": "2.13.0",

--- a/src/errors/module-missing.js
+++ b/src/errors/module-missing.js
@@ -1,4 +1,4 @@
-import { red, green } from 'colors/safe';
+import { red, green } from 'chalk';
 
 import { line } from '../packages/logger';
 

--- a/src/packages/cli/commands/create.js
+++ b/src/packages/cli/commands/create.js
@@ -1,5 +1,5 @@
 import Ora from 'ora';
-import { green } from 'colors/safe';
+import { green } from 'chalk';
 
 import fs from '../../fs';
 

--- a/src/packages/cli/commands/destroy.js
+++ b/src/packages/cli/commands/destroy.js
@@ -1,4 +1,4 @@
-import { red } from 'colors/safe';
+import { red } from 'chalk';
 import { pluralize } from 'inflection';
 
 import fs from '../../fs';

--- a/src/packages/cli/commands/generate.js
+++ b/src/packages/cli/commands/generate.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { green } from 'colors/safe';
+import { green } from 'chalk';
 import { pluralize } from 'inflection';
 
 import fs from '../../fs';

--- a/src/packages/cli/commands/serve.js
+++ b/src/packages/cli/commands/serve.js
@@ -1,7 +1,7 @@
 import os from 'os';
 import cluster from 'cluster';
 
-import { cyan } from 'colors/safe';
+import { cyan } from 'chalk';
 
 import Logger from '../../logger';
 

--- a/src/packages/database/errors/invalid-driver.js
+++ b/src/packages/database/errors/invalid-driver.js
@@ -1,4 +1,4 @@
-import { green, yellow } from 'colors/safe';
+import { green, yellow } from 'chalk';
 
 import { VALID_DRIVERS } from '../constants';
 

--- a/src/packages/database/errors/migrations-pending.js
+++ b/src/packages/database/errors/migrations-pending.js
@@ -1,4 +1,4 @@
-import { green, yellow } from 'colors/safe';
+import { green, yellow } from 'chalk';
 
 import { line } from '../../logger';
 

--- a/src/packages/logger/index.js
+++ b/src/packages/logger/index.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { dim, red, yellow } from 'colors/safe';
+import { dim, red, yellow } from 'chalk';
 
 import fs from '../fs';
 

--- a/src/packages/server/index.js
+++ b/src/packages/server/index.js
@@ -1,7 +1,7 @@
 import http from 'http';
 import { parse as parseURL } from 'url';
 
-import colors from 'colors/safe';
+import chalk, { cyan } from 'chalk';
 
 import Base from '../base';
 import Session from '../session';
@@ -67,10 +67,10 @@ class Server extends Base {
       }
 
       this.logger.log(line`
-        ${colors.cyan(`${method}`)} ${url.pathname} -> Finished after
+        ${cyan(`${method}`)} ${url.pathname} -> Finished after
         ${new Date().getTime() - startTime.getTime()} ms with
-        ${colors[statusColor].call(null, `${statusCode}`)}
-        ${colors[statusColor].call(null, `${statusMessage}`)}
+        ${chalk[statusColor].call(null, `${statusCode}`)}
+        ${chalk[statusColor].call(null, `${statusMessage}`)}
       `);
     });
   }

--- a/test/test-app/config/environments/development.js
+++ b/test/test-app/config/environments/development.js
@@ -1,5 +1,5 @@
 export default {
-  log: false,
+  log: true,
   domain: 'http://localhost:4000',
   sessionKey: 'test-app::development::session',
   sessionSecret: '73689ad1adec9d7f055c41de52e415b9678f0ad421579d471038519372b4522e'


### PR DESCRIPTION
This PR refactors Lux to use [chalk](https://www.npmjs.com/package/chalk) instead of [colors](https://www.npmjs.com/package/colors). Since chalk seems to be the better package and [ora](https://www.npmjs.com/package/ora) has a peer dependency of [chalk](https://www.npmjs.com/package/chalk), it makes sense to use it in place of [colors](https://www.npmjs.com/package/colors). 
