### PR TITLE
fix: remove short -db flag from lux new cmd

### DIFF
--- a/src/packages/cli/index.js
+++ b/src/packages/cli/index.js
@@ -26,7 +26,7 @@ cli
   .command('n <name>')
   .alias('new')
   .description('Create a new application')
-  .option('-db, --database [database]', '(Default: sqlite)')
+  .option('--database [database]', '(Default: sqlite)')
   .action(async (name, { database = 'sqlite' } = {}) => {
     await tryCatch(async () => {
       if (VALID_DATABASES.indexOf(database) < 0) {


### PR DESCRIPTION
Using `-db` doesn't work with commander. This PR removes that option from the `--help` prompt in favor of the longer `--database` flag.

--
Closes #85 