### PR TITLE
fix: middleware functions added in 'beforeAction' not executing

### DIFF
--- a/src/packages/application/index.js
+++ b/src/packages/application/index.js
@@ -75,7 +75,8 @@ class Application extends Base {
       serializer.serializers = serializers;
     });
 
-    const appController = controllers.get('application').create({
+    let appController = controllers.get('application');
+    appController = new appController({
       store,
       domain,
       serializers,
@@ -88,7 +89,7 @@ class Application extends Base {
       if (key !== 'application') {
         const model = store.modelFor(singularize(key));
 
-        controller = controller.create({
+        controller = new controller({
           store,
           model,
           domain,

--- a/src/packages/controller/index.js
+++ b/src/packages/controller/index.js
@@ -1,13 +1,14 @@
 import Promise from 'bluebird';
 
-import Base from '../base';
-
 import formatInclude from './utils/format-include';
 import createPageLinks from './utils/create-page-links';
 
 import action from './decorators/action';
 
-class Controller extends Base {
+const { isArray } = Array;
+const { defineProperties } = Object;
+
+class Controller {
   store;
   model;
   domain;
@@ -16,73 +17,146 @@ class Controller extends Base {
   attributes;
   serializer;
   serializers;
+  parentController;
 
-  sort = [];
-  filter = [];
   params = [];
   beforeAction = [];
   defaultPerPage = 25;
 
-  constructor({ model, serializer, parentController, ...props }) {
+  _sort = [];
+  _filter = [];
+
+  constructor({
+    store,
+    model,
+    domain,
+    serializer,
+    serializers = new Map(),
+    parentController
+  }) {
     let attributes = [];
+    let relationships = [];
 
-    super();
+    if (model && serializer) {
+      const { primaryKey, attributeNames, relationshipNames } = model;
+      const { attributes: serializedAttributes } = serializer;
+      const serializedRelationships = [
+        ...serializer.hasOne,
+        ...serializer.hasMany
+      ];
 
-    if (model) {
-      props = {
-        ...props,
-        model,
-        modelName: model.modelName
-      };
+      attributes = attributeNames.filter(attr => {
+        return attr === primaryKey || serializedAttributes.indexOf(attr) >= 0;
+      });
 
-      attributes = model.attributeNames;
+      relationships = relationshipNames.filter(relationship => {
+        return serializedRelationships.indexOf(relationship) >= 0;
+      });
+    }
 
-      if (!this.sort.length) {
-        props.sort = attributes;
+    defineProperties(this, {
+      model: {
+        value: model,
+        writable: false,
+        enumerable: true,
+        configurable: false
+      },
+
+      serializer: {
+        value: serializer,
+        writable: false,
+        enumerable: true,
+        configurable: false
+      },
+
+      store: {
+        value: store,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      },
+
+      domain: {
+        value: domain,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      },
+
+      modelName: {
+        value: model ? model.modelName : null,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      },
+
+      attributes: {
+        value: attributes,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      },
+
+      relationships: {
+        value: relationships,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      },
+
+      serializers: {
+        value: serializers,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      },
+
+      parentController: {
+        value: parentController,
+        writable: false,
+        enumerable: false,
+        configurable: false
       }
-
-      if (!this.filter.length) {
-        props.filter = attributes;
-      }
-    }
-
-    if (serializer) {
-      props = {
-        ...props,
-        serializer,
-
-        attributes: ['id', ...serializer.attributes]
-          .filter(attr => {
-            return attributes.indexOf(attr) >= 0;
-          }),
-
-        relationships: [
-          ...serializer.hasOne,
-          ...serializer.hasMany
-        ]
-      };
-    }
-
-    if (parentController) {
-      props = {
-        ...props,
-        parentController,
-
-        middleware: [
-          ...parentController.middleware,
-          ...this.beforeAction
-        ]
-      };
-    } else {
-      props = {
-        ...props,
-        middleware: this.beforeAction
-      };
-    }
-
-    this.setProps(props);
+    });
 
     return this;
+  }
+
+  get sort() {
+    const { attributes, _sort: sort } = this;
+
+    return sort.length ? sort : attributes;
+  }
+
+  set sort(value = []) {
+    if (isArray(value)) {
+      this._sort = value;
+    }
+  }
+
+  get filter() {
+    const { attributes, _filter: filter } = this;
+
+    return filter.length ? filter : attributes;
+  }
+
+  set filter(value = []) {
+    if (isArray(value)) {
+      this._filter = value;
+    }
+  }
+
+  get middleware() {
+    const { beforeAction, parentController } = this;
+
+    if (parentController) {
+      return [
+        ...parentController.middleware,
+        ...beforeAction
+      ];
+    } else {
+      return beforeAction;
+    }
   }
 
   @action

--- a/test/integration/controller.js
+++ b/test/integration/controller.js
@@ -465,4 +465,24 @@ describe('Integration: class Controller', () => {
       expect(subject.status).to.equal(204);
     });
   });
+
+  describe('Regression: #middleware (https://github.com/postlight/lux/issues/94)', () => {
+    let subject;
+
+    before(async () => {
+      subject = await fetch(`${host}/posts`);
+    });
+
+    it('includes middleware from it\'s `parentController`', () => {
+      expect(
+        subject.headers.get('X-Powered-By')
+      ).to.equal('Lux');
+    });
+
+    it('includes middleware defined in `beforeAction`', () => {
+      expect(
+        subject.headers.get('X-Controller')
+      ).to.equal('Posts');
+    });
+  });
 });

--- a/test/test-app/app/controllers/application.js
+++ b/test/test-app/app/controllers/application.js
@@ -1,7 +1,11 @@
 import { Controller } from '../../../../dist';
 
 class ApplicationController extends Controller {
-
+  beforeAction = [
+    function (req, res) {
+      res.setHeader('X-Powered-By', 'Lux');
+    }
+  ];
 }
 
 export default ApplicationController;

--- a/test/test-app/app/controllers/authors.js
+++ b/test/test-app/app/controllers/authors.js
@@ -4,6 +4,12 @@ class AuthorsController extends Controller {
   params = [
     'name'
   ];
+
+  beforeAction = [
+    function (req, res) {
+      res.setHeader('X-Controller', 'Authors');
+    }
+  ];
 }
 
 export default AuthorsController;

--- a/test/test-app/app/controllers/posts.js
+++ b/test/test-app/app/controllers/posts.js
@@ -6,6 +6,12 @@ class PostsController extends Controller {
     'body',
     'isPublic'
   ];
+
+  beforeAction = [
+    function (req, res) {
+      res.setHeader('X-Controller', 'Posts');
+    }
+  ];
 }
 
 export default PostsController;


### PR DESCRIPTION
This PR fixes the issue of middleware not being executed when added to the `beforeAction` array on a `Controller`.

The reason this bug exists is because #65 introduced many improvements where previously computed properties were moved to it's classes constructor in attempt to prevent multiple executions of a `getter`. The downside of doing this is that class properties will not be installed on the `prototype` until after the constructor is called. This simply moves the `middleware` property back to a computed `getter` function which is later memoized in the `Route` class upon the application's boot so there is no perf regression.

This PR also removes the parent class `Base` from `Controller` which is part of an ongoing refactor to no longer be using `Base` as a parent for packages within Lux. It doesn't provide any additional functionality since we can mimic `setProps` with `Object.assign(this, props)` and it will be better to not dirty the prototype chain moving forward unless it's absolutely necessary.

--

Closes #94 