### PR TITLE
fix: select statement not being optimized by fields param

### DIFF
--- a/src/packages/application/index.js
+++ b/src/packages/application/index.js
@@ -59,9 +59,10 @@ class Application extends Base {
     serializers.forEach((serializer, name) => {
       const model = models.get(singularize(name));
 
-      serializer = serializer.create({
+      serializer = new serializer({
         model,
-        domain
+        domain,
+        serializers
       });
 
       if (model) {
@@ -69,10 +70,6 @@ class Application extends Base {
       }
 
       serializers.set(name, serializer);
-    });
-
-    serializers.forEach(serializer => {
-      serializer.serializers = serializers;
     });
 
     let appController = controllers.get('application');

--- a/src/packages/controller/utils/format-include.js
+++ b/src/packages/controller/utils/format-include.js
@@ -1,3 +1,5 @@
+import { singularize } from 'inflection';
+
 export default function formatInclude(model, include, fields, relationships) {
   return relationships.reduce((included, value) => {
     const relationship = model.getRelationship(value);
@@ -15,7 +17,7 @@ export default function formatInclude(model, include, fields, relationships) {
         }
       } = relationship;
 
-      let fieldsForRelationship = fields[value];
+      let fieldsForRelationship = fields[singularize(value)];
 
       if (fieldsForRelationship) {
         fieldsForRelationship = fieldsForRelationship.filter(attr => {


### PR DESCRIPTION
Fixes a bug where `?include=comments&fields[comment]=message` would not optimize the `SELECT ... FROM comments` statement. Also refactors serializer to be more functional and not extend `Base`.