### PR TITLE
feat: improve error handling on missing controller & serializer files

### DIFF
--- a/src/packages/application/errors/controller-missing.js
+++ b/src/packages/application/errors/controller-missing.js
@@ -1,0 +1,7 @@
+class ControllerMissingError extends Error {
+  constructor(resource) {
+    return super(`Could not resolve controller by name '${resource}'`);
+  }
+}
+
+export default ControllerMissingError;

--- a/src/packages/application/errors/index.js
+++ b/src/packages/application/errors/index.js
@@ -1,0 +1,2 @@
+export ControllerMissingError from './controller-missing';
+export SerializerMissingError from './serializer-missing';

--- a/src/packages/application/errors/serializer-missing.js
+++ b/src/packages/application/errors/serializer-missing.js
@@ -1,0 +1,7 @@
+class SerializerMissingError extends Error {
+  constructor(resource) {
+    return super(`Could not resolve serializer by name '${resource}'`);
+  }
+}
+
+export default SerializerMissingError;

--- a/src/packages/application/index.js
+++ b/src/packages/application/index.js
@@ -1,12 +1,17 @@
 import Promise from 'bluebird';
 import cluster from 'cluster';
-import { singularize } from 'inflection';
+import { pluralize, singularize } from 'inflection';
 
 import Server from '../server';
 import Router from '../router';
 import Database from '../database';
 
 import loader from '../loader';
+
+import {
+  ControllerMissingError,
+  SerializerMissingError
+} from './errors';
 
 const { defineProperties } = Object;
 
@@ -114,6 +119,18 @@ class Application {
     ]);
 
     await store.define(models);
+
+    models.forEach((model, name) => {
+      const resource = pluralize(name);
+
+      if (!controllers.get(resource)) {
+        throw new ControllerMissingError(resource);
+      }
+
+      if (!serializers.get(resource)) {
+        throw new SerializerMissingError(resource);
+      }
+    });
 
     serializers.forEach((serializer, name) => {
       const model = models.get(singularize(name));


### PR DESCRIPTION
We now have the following messages when a file is missing

```
Error: Could not resolve model by name 'user'
Error: Could not resolve controller by name 'users'
Error: Could not resolve serializer by name 'users'
```

Fixes #104