### PR TITLE
refactor: rename serializer methods and return objects

### DIFF
--- a/src/packages/controller/index.js
+++ b/src/packages/controller/index.js
@@ -412,8 +412,6 @@ class Controller {
       }
     } = req;
 
-    res.statusCode = 201;
-
     return this.model.create(attributes);
   }
 

--- a/src/packages/route/utils/create-action.js
+++ b/src/packages/route/utils/create-action.js
@@ -19,7 +19,7 @@ export default function createAction(
   controller: Controller,
   action: () => Promise
 ): Array<Function> {
-  const { middleware } = controller;
+  const { middleware, serializer } = controller;
 
   const builtIns = [
     sanitizeParams,
@@ -83,7 +83,7 @@ export default function createAction(
             })
           };
 
-          return controller.serializer.stream({
+          return serializer.format({
             data,
             links,
             domain,
@@ -99,7 +99,7 @@ export default function createAction(
             fields = controller.attributes;
           }
 
-          return controller.serializer.stream({
+          return serializer.format({
             data,
             links,
             domain,

--- a/src/packages/serializer/index.js
+++ b/src/packages/serializer/index.js
@@ -1,7 +1,6 @@
 // @flow
 import { pluralize } from 'inflection';
 
-import ContentStream from '../content-stream';
 import { Model } from '../database';
 
 import pick from '../../utils/pick';
@@ -296,36 +295,7 @@ class Serializer {
   /**
    * @private
    */
-  stream({
-    data,
-    links = {},
-    fields = [],
-    domain = '',
-    include = {}
-  }: {
-    data?: ?(Model | Array<Model>);
-    links?: Object;
-    fields?: Array<string>;
-    domain?: string;
-    include?: Object;
-  }): ContentStream {
-    return new ContentStream().once('ready', (stream: ContentStream) => {
-      const serialized = this.serialize({
-        data,
-        links,
-        fields,
-        domain,
-        include
-      });
-
-      stream.end(serialized);
-    });
-  }
-
-  /**
-   * @private
-   */
-  serialize({
+  format({
     data,
     links,
     fields,
@@ -354,7 +324,7 @@ class Serializer {
           ...serialized,
 
           data: data.map(item => {
-            return this.serializeOne({
+            return this.formatOne({
               item,
               fields,
               domain,
@@ -367,7 +337,7 @@ class Serializer {
         serialized = {
           ...serialized,
 
-          data: this.serializeOne({
+          data: this.formatOne({
             fields,
             domain,
             include,
@@ -407,7 +377,7 @@ class Serializer {
   /**
    * @private
    */
-  serializeOne({
+  formatOne({
     item,
     links,
     fields,
@@ -451,7 +421,7 @@ class Serializer {
         attrs = attrs.filter(field => !idRegExp.test(field));
 
         if (related instanceof Model) {
-          hash[name] = this.serializeRelationship({
+          hash[name] = this.formatRelationship({
             domain,
             included,
             item: related,
@@ -464,7 +434,7 @@ class Serializer {
               const {
                 data: relatedData,
                 links: relatedLinks
-              } = this.serializeRelationship({
+              } = this.formatRelationship({
                 domain,
                 included,
                 item: relatedItem,
@@ -503,7 +473,7 @@ class Serializer {
   /**
    * @private
    */
-  serializeRelationship({
+  formatRelationship({
     item,
     fields,
     domain,
@@ -532,7 +502,7 @@ class Serializer {
 
       if (shouldInclude) {
         included.push(
-          serializer.serializeOne({
+          serializer.formatOne({
             item,
             domain,
             fields,

--- a/src/packages/server/index.js
+++ b/src/packages/server/index.js
@@ -25,7 +25,9 @@ import type Router from '../router';
  */
 class Server {
   router: Router;
+
   logger: Logger;
+
   instance: HTTPServer;
 
   constructor({
@@ -95,17 +97,21 @@ class Server {
         };
       }
 
-      this.sendResponse(res, await this.router.visit(req, res));
+      this.sendResponse(req, res, await this.router.visit(req, res));
     }, err => {
-      this.sendResponse(res, err);
+      this.sendResponse(req, res, err);
     });
   }
 
-  sendResponse(res: ServerResponse, data: void | mixed): void {
+  sendResponse(
+    req: IncomingMessage,
+    res: ServerResponse,
+    data: void | ?mixed
+  ): void {
     if (data && typeof data.pipe === 'function') {
       data.pipe(res);
     } else {
-      responder.resolve(res, data);
+      responder.resolve(req, res, data);
     }
   }
 

--- a/src/packages/server/responder/index.js
+++ b/src/packages/server/responder/index.js
@@ -1,13 +1,13 @@
 // @flow
-import ContentStream from '../../content-stream';
+import Response from './response';
 
 import normalize from './utils/normalize';
 
 import type { ServerResponse } from 'http';
 
 export function resolve(res: ServerResponse, data: ?mixed | void): void {
-  new ContentStream()
-    .once('ready', (stream: ContentStream) => {
+  new Response()
+    .once('ready', (stream: Response) => {
       const {
         normalized,
         statusCode

--- a/src/packages/server/responder/index.js
+++ b/src/packages/server/responder/index.js
@@ -3,15 +3,23 @@ import Response from './response';
 
 import normalize from './utils/normalize';
 
-import type { ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 
-export function resolve(res: ServerResponse, data: ?mixed | void): void {
+export function resolve(
+  req: IncomingMessage,
+  res: ServerResponse,
+  data: ?mixed | void
+): void {
   new Response()
     .once('ready', (stream: Response) => {
-      const {
+      let {
         normalized,
         statusCode
       } = normalize(data);
+
+      if (statusCode === 200 && req.method === 'POST') {
+        statusCode++;
+      }
 
       res.statusCode = statusCode;
       stream.end(normalized);

--- a/src/packages/server/responder/response/index.js
+++ b/src/packages/server/responder/response/index.js
@@ -1,7 +1,7 @@
 import { Transform } from 'stream';
 
-class ContentStream extends Transform {
-  constructor(): ContentStream {
+class Response extends Transform {
+  constructor(): Response {
     super({
       encoding: 'utf8',
       writableObjectMode: true
@@ -29,4 +29,4 @@ class ContentStream extends Transform {
   }
 }
 
-export default ContentStream;
+export default Response;

--- a/src/packages/server/responder/utils/data-for.js
+++ b/src/packages/server/responder/utils/data-for.js
@@ -1,7 +1,10 @@
 // @flow
 import { STATUS_CODES } from '../constants.js';
 
-export default function responseFor(
+/**
+ * @private
+ */
+export default function dataFor(
   status: number,
   err?: Error
 ): void | Object {

--- a/src/packages/server/responder/utils/normalize.js
+++ b/src/packages/server/responder/utils/normalize.js
@@ -1,6 +1,6 @@
 // @flow
 import { STATUS_CODES } from '../constants';
-import responseFor from './response-for';
+import dataFor from './data-for';
 
 export default function normalize(data: ?mixed | void): {
   normalized: mixed;
@@ -15,7 +15,7 @@ export default function normalize(data: ?mixed | void): {
         statusCode = 204;
       } else {
         statusCode = 401;
-        normalized = responseFor(statusCode);
+        normalized = dataFor(statusCode);
       }
       break;
 
@@ -25,22 +25,24 @@ export default function normalize(data: ?mixed | void): {
       } else {
         statusCode = 404;
       }
-      normalized = responseFor(statusCode);
+      normalized = dataFor(statusCode);
       break;
 
     case 'object':
       if (!data) {
         statusCode = 404;
-        normalized = responseFor(statusCode);
+        normalized = dataFor(statusCode);
       } else if (data instanceof Error) {
         statusCode = 500;
-        normalized = responseFor(statusCode, data);
+        normalized = dataFor(statusCode, data);
+      } else {
+        normalized = data;
       }
       break;
 
     case 'undefined':
       statusCode = 404;
-      normalized = responseFor(statusCode);
+      normalized = dataFor(statusCode);
       break;
 
     default:


### PR DESCRIPTION
This PR refactors `Serializer` to return objects rather than streams as data will be transformed to a stream before the req/res is completed anyways. Also, Serializer methods now have more appropriate names such as `Serializer#format` vs `Serializer#serializer`.