### PR TITLE
refactor: use process.cwd() instead of process.env.PWD

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const PWD = process.env.PWD;
+const PWD = process.cwd();
 
 try {
   require(`${PWD}/node_modules/lux-framework/dist/cli`).call(null);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,6 @@
+// @flow
+const { env: ENV } = process;
+
+export const CWD = process.cwd();
+export const PORT = parseInt(ENV.PORT, 10) || 4000;
+export const NODE_ENV = ENV.NODE_ENV || 'development';

--- a/src/packages/cli/commands/create.js
+++ b/src/packages/cli/commands/create.js
@@ -1,6 +1,8 @@
 import Ora from 'ora';
 import { green } from 'chalk';
 
+import { CWD } from '../../../constants';
+
 import fs from '../../fs';
 import template from '../../template';
 
@@ -26,7 +28,7 @@ import gitignoreTemplate from '../templates/gitignore';
  */
 export default async function create(name, database) {
   const driver = driverFor(database);
-  const project = `${process.env.PWD}/${name}`;
+  const project = `${CWD}/${name}`;
 
   await fs.mkdirAsync(project);
 

--- a/src/packages/cli/commands/db-create.js
+++ b/src/packages/cli/commands/db-create.js
@@ -1,8 +1,7 @@
+import { CWD, NODE_ENV } from '../../../constants';
 import fs from '../../fs';
 import loader from '../../loader';
 import { connect } from '../../database';
-
-const { env: { PWD, NODE_ENV = 'development' } } = process;
 
 /**
  * @private
@@ -16,12 +15,12 @@ export default async function dbCreate() {
         ...config
       }
     }
-  } = loader(PWD, 'config');
+  } = loader(CWD, 'config');
 
   if (driver === 'sqlite3') {
-    await fs.writeFileAsync(`${PWD}/db/${database}_${NODE_ENV}.sqlite`, '');
+    await fs.writeFileAsync(`${CWD}/db/${database}_${NODE_ENV}.sqlite`, '');
   } else {
-    const { schema } = connect(PWD, { ...config, driver });
+    const { schema } = connect(CWD, { ...config, driver });
     const query = schema.raw(`CREATE DATABASE ${database}`);
 
     query.on('query', () => console.log(query.toString()));

--- a/src/packages/cli/commands/db-drop.js
+++ b/src/packages/cli/commands/db-drop.js
@@ -1,8 +1,7 @@
+import { CWD, NODE_ENV } from '../../../constants';
 import { connect } from '../../database';
 import { rmrf } from '../../fs';
 import loader from '../../loader';
-
-const { env: { PWD, NODE_ENV = 'development' } } = process;
 
 /**
  * @private
@@ -16,12 +15,12 @@ export default async function dbDrop() {
         ...config
       }
     }
-  } = loader(PWD, 'config');
+  } = loader(CWD, 'config');
 
   if (driver === 'sqlite3') {
-    await rmrf(`${PWD}/db/${database}_${NODE_ENV}.sqlite`);
+    await rmrf(`${CWD}/db/${database}_${NODE_ENV}.sqlite`);
   } else {
-    const { schema } = connect(PWD, { ...config, driver });
+    const { schema } = connect(CWD, { ...config, driver });
     const query = schema.raw(`DROP DATABASE IF EXISTS ${database}`);
 
     query.on('query', () => console.log(query.toString()));

--- a/src/packages/cli/commands/db-migrate.js
+++ b/src/packages/cli/commands/db-migrate.js
@@ -1,30 +1,29 @@
+import { CWD } from '../../../constants';
 import Database, { pendingMigrations } from '../../database';
 import Logger, { sql } from '../../logger';
 import loader from '../../loader';
-
-const { env: { PWD } } = process;
 
 /**
  * @private
  */
 export default async function dbMigrate() {
-  const { database: config } = loader(PWD, 'config');
-  const models = loader(PWD, 'models');
-  const migrations = loader(PWD, 'migrations');
+  const { database: config } = loader(CWD, 'config');
+  const models = loader(CWD, 'models');
+  const migrations = loader(CWD, 'migrations');
 
   const { connection, schema } = await new Database({
     config,
     models,
-    path: PWD,
+    path: CWD,
     checkMigrations: false,
 
     logger: await new Logger({
-      path: PWD,
+      path: CWD,
       enabled: false
     })
   });
 
-  const pending = await pendingMigrations(PWD, () => connection('migrations'));
+  const pending = await pendingMigrations(CWD, () => connection('migrations'));
 
   if (pending.length) {
     await Promise.all(

--- a/src/packages/cli/commands/db-rollback.js
+++ b/src/packages/cli/commands/db-rollback.js
@@ -1,31 +1,30 @@
+import { CWD } from '../../../constants';
 import Database from '../../database';
 import Logger, { sql } from '../../logger';
 import fs from '../../fs';
 import loader from '../../loader';
 
-const { env: { PWD } } = process;
-
 /**
  * @private
  */
 export default async function dbRollback() {
-  const { database: config } = loader(PWD, 'config');
-  const models = loader(PWD, 'models');
-  const migrations = loader(PWD, 'migrations');
+  const { database: config } = loader(CWD, 'config');
+  const models = loader(CWD, 'models');
+  const migrations = loader(CWD, 'migrations');
 
   const { connection, schema } = await new Database({
     config,
     models,
-    path: PWD,
+    path: CWD,
     checkMigrations: false,
 
     logger: await new Logger({
-      path: PWD,
+      path: CWD,
       enabled: false
     })
   });
 
-  const migrationFiles = await fs.readdirAsync(`${PWD}/db/migrate`);
+  const migrationFiles = await fs.readdirAsync(`${CWD}/db/migrate`);
 
   if (migrationFiles.length) {
     let migration;

--- a/src/packages/cli/commands/db-seed.js
+++ b/src/packages/cli/commands/db-seed.js
@@ -1,24 +1,23 @@
+import { CWD } from '../../../constants';
 import Logger from '../../logger';
 import Database from '../../database';
 import loader from '../../loader';
-
-const { env: { PWD } } = process;
 
 /**
  * @private
  */
 export default async function dbSeed() {
-  const { database: config } = loader(PWD, 'config');
-  const seed = loader(PWD, 'seed');
-  const models = loader(PWD, 'models');
+  const { database: config } = loader(CWD, 'config');
+  const seed = loader(CWD, 'seed');
+  const models = loader(CWD, 'models');
 
   await new Database({
     config,
     models,
-    path: PWD,
+    path: CWD,
 
     logger: await new Logger({
-      path: PWD,
+      path: CWD,
       enabled: false
     })
   });

--- a/src/packages/cli/commands/destroy.js
+++ b/src/packages/cli/commands/destroy.js
@@ -1,9 +1,8 @@
+import { CWD } from '../../../constants';
 import { red, green } from 'chalk';
 import { pluralize } from 'inflection';
 
 import fs, { rmrf, exists } from '../../fs';
-
-const { env: { PWD } } = process;
 
 /**
  * @private
@@ -19,7 +18,7 @@ export async function destroyType(type, name) {
       break;
 
     case 'migration':
-      const migrations = await fs.readdirAsync(`${PWD}/db/migrate`);
+      const migrations = await fs.readdirAsync(`${CWD}/db/migrate`);
 
       name = migrations.find(file => `${name}.js` === file.substr(17));
       path = `db/migrate/${name}`;
@@ -32,8 +31,8 @@ export async function destroyType(type, name) {
       break;
   }
 
-  if (await exists(`${PWD}/${path}`)) {
-    await rmrf(`${PWD}/${path}`);
+  if (await exists(`${CWD}/${path}`)) {
+    await rmrf(`${CWD}/${path}`);
     console.log(`${red('remove')} ${path}`);
   }
 }
@@ -43,7 +42,7 @@ export async function destroyType(type, name) {
  */
 export default async function destroy(type, name) {
   if (type === 'resource') {
-    const routes = (await fs.readFileAsync(`${PWD}/app/routes.js`, 'utf8'))
+    const routes = (await fs.readFileAsync(`${CWD}/app/routes.js`, 'utf8'))
       .split('\n')
       .reduce((lines, line) => {
         const pattern = new RegExp(
@@ -61,7 +60,7 @@ export default async function destroy(type, name) {
       destroyType('controller', name)
     ]);
 
-    await fs.writeFileAsync(`${PWD}/app/routes.js`, routes, 'utf8');
+    await fs.writeFileAsync(`${CWD}/app/routes.js`, routes, 'utf8');
     console.log(`${green('update')} app/routes.js`);
   } else if (type === 'model') {
     await Promise.all([

--- a/src/packages/cli/commands/generate.js
+++ b/src/packages/cli/commands/generate.js
@@ -3,6 +3,7 @@ import { red, green, yellow } from 'chalk';
 import { pluralize } from 'inflection';
 import { createInterface } from 'readline';
 
+import { CWD } from '../../../constants';
 import fs, { rmrf, exists } from '../../fs';
 
 import modelTemplate from '../templates/model';
@@ -13,12 +14,10 @@ import modelMigrationTemplate from '../templates/model-migration';
 
 import indent from '../utils/indent';
 
-const { env: { PWD } } = process;
-
 /**
  * @private
  */
-export async function generateType(type, name, pwd, attrs = []) {
+export async function generateType(type, name, cwd, attrs = []) {
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout
@@ -74,9 +73,9 @@ export async function generateType(type, name, pwd, attrs = []) {
   if (isMigration) {
     const regexp = new RegExp(`^\\d+-${path.split('/').pop().substr(17)}$`);
 
-    doesExist = await exists(regexp, `${pwd}/db/migrate`);
+    doesExist = await exists(regexp, `${cwd}/db/migrate`);
   } else {
-    doesExist = await exists(`${pwd}/${path}`);
+    doesExist = await exists(`${cwd}/${path}`);
   }
 
   if (doesExist) {
@@ -89,7 +88,7 @@ export async function generateType(type, name, pwd, attrs = []) {
 
     if (overwrite) {
       if (isMigration) {
-        const migrations = await fs.readdirAsync(`${pwd}/db/migrate`);
+        const migrations = await fs.readdirAsync(`${cwd}/db/migrate`);
         const isModelMigration = type === 'model-migration';
 
         const oldName = migrations.find(file => {
@@ -100,21 +99,21 @@ export async function generateType(type, name, pwd, attrs = []) {
         if (oldName) {
           const oldPath = `db/migrate/${oldName}`;
 
-          await rmrf(`${pwd}/${oldPath}`);
+          await rmrf(`${cwd}/${oldPath}`);
           console.log(`${red('remove')} ${oldPath}`);
         }
 
-        await fs.writeFileAsync(`${pwd}/${path}`, data, 'utf8');
+        await fs.writeFileAsync(`${cwd}/${path}`, data, 'utf8');
         console.log(`${green('create')} ${path}`);
       } else {
-        await fs.writeFileAsync(`${pwd}/${path}`, data, 'utf8');
+        await fs.writeFileAsync(`${cwd}/${path}`, data, 'utf8');
         console.log(`${yellow('overwrite')} ${path}`);
       }
     } else {
       console.log(`${yellow('skip')} ${path}`);
     }
   } else {
-    await fs.writeFileAsync(`${pwd}/${path}`, data, 'utf8');
+    await fs.writeFileAsync(`${cwd}/${path}`, data, 'utf8');
     console.log(`${green('create')} ${path}`);
   }
 
@@ -124,9 +123,9 @@ export async function generateType(type, name, pwd, attrs = []) {
 /**
  * @private
  */
-export default async function generate(type, name, pwd = PWD, attrs = []) {
+export default async function generate(type, name, cwd = CWD, attrs = []) {
   if (type === 'resource') {
-    const routes = (await fs.readFileAsync(`${pwd}/app/routes.js`, 'utf8'))
+    const routes = (await fs.readFileAsync(`${cwd}/app/routes.js`, 'utf8'))
       .split('\n')
       .reduce((str, line, index, array) => {
         const closeIndex = array.lastIndexOf('}');
@@ -142,17 +141,17 @@ export default async function generate(type, name, pwd = PWD, attrs = []) {
         return str;
       }, '');
 
-    await generateType('model', name, pwd, attrs);
-    await generateType('model-migration', name, pwd, attrs);
-    await generateType('serializer', name, pwd, attrs);
-    await generateType('controller', name, pwd, attrs);
+    await generateType('model', name, cwd, attrs);
+    await generateType('model-migration', name, cwd, attrs);
+    await generateType('serializer', name, cwd, attrs);
+    await generateType('controller', name, cwd, attrs);
 
-    await fs.writeFileAsync(`${pwd}/app/routes.js`, routes, 'utf8');
+    await fs.writeFileAsync(`${cwd}/app/routes.js`, routes, 'utf8');
     console.log(`${green('update')} app/routes.js`);
   } else if (type === 'model') {
-    await generateType(type, name, pwd, attrs);
-    await generateType('model-migration', name, pwd, attrs);
+    await generateType(type, name, cwd, attrs);
+    await generateType('model-migration', name, cwd, attrs);
   } else {
-    await generateType(type, name, pwd, attrs);
+    await generateType(type, name, cwd, attrs);
   }
 }

--- a/src/packages/cli/commands/serve.js
+++ b/src/packages/cli/commands/serve.js
@@ -1,25 +1,18 @@
 // @flow
 import { cyan } from 'chalk';
 
+import { CWD, PORT } from '../../../constants';
 import Logger from '../../logger';
 import { createCluster } from '../../pm';
-
-const { env: { PWD, PORT } } = process;
 
 /**
  * @private
  */
-export default async function serve(
-  port: ?number | ?string = PORT
-): Promise<void> {
-  let path = PWD;
+export default async function serve(port: number = PORT): Promise<void> {
+  let path = CWD;
 
   if (typeof path !== 'string') {
     path = __dirname;
-  }
-
-  if (typeof port !== 'number') {
-    port = 4000;
   }
 
   const logger = await new Logger({

--- a/src/packages/cli/index.js
+++ b/src/packages/cli/index.js
@@ -1,5 +1,6 @@
 import cli from 'commander';
 
+import { CWD, NODE_ENV } from '../../constants';
 import { VALID_DATABASES } from './constants';
 import { version as VERSION } from '../../../package.json';
 
@@ -25,15 +26,7 @@ import {
  * @private
  */
 export default function CLI() {
-  const {
-    argv,
-    exit,
-
-    env: {
-      PWD,
-      NODE_ENV = 'development'
-    }
-  } = process;
+  const { argv, exit } = process;
 
   /**
    * @private
@@ -92,15 +85,15 @@ export default function CLI() {
         process.env.NODE_ENV = environment;
 
         if (hot) {
-          const watcher = await new Watcher(PWD);
+          const watcher = await new Watcher(CWD);
 
           watcher.on('change', async (changed) => {
-            await compile(PWD, environment);
+            await compile(CWD, environment);
             process.emit('update', changed);
           });
         }
 
-        await compile(PWD, environment, {
+        await compile(CWD, environment, {
           useStrict
         });
 
@@ -118,7 +111,7 @@ export default function CLI() {
       return tryCatch(async () => {
         if (typeof type === 'string' && typeof name === 'string') {
           args = args.filter(a => typeof a === 'string');
-          await generate(type, name, PWD, args);
+          await generate(type, name, CWD, args);
           exit(0);
         } else {
           throw new TypeError('Invalid arguements for type or name');
@@ -148,7 +141,7 @@ export default function CLI() {
     .description('Create your database schema')
     .action(() => {
       return tryCatch(async () => {
-        await compile(PWD, NODE_ENV);
+        await compile(CWD, NODE_ENV);
         await dbCreate();
         exit(0);
       }, rescue);
@@ -159,7 +152,7 @@ export default function CLI() {
     .description('Drop your database schema')
     .action(() => {
       return tryCatch(async () => {
-        await compile(PWD, NODE_ENV);
+        await compile(CWD, NODE_ENV);
         await dbDrop();
         exit(0);
       }, rescue);
@@ -170,7 +163,7 @@ export default function CLI() {
     .description('Drop your database schema and create a new schema')
     .action(() => {
       return tryCatch(async () => {
-        await compile(PWD, NODE_ENV);
+        await compile(CWD, NODE_ENV);
         await dbDrop();
         await dbCreate();
         exit(0);
@@ -182,7 +175,7 @@ export default function CLI() {
     .description('Run database migrations')
     .action(() => {
       return tryCatch(async () => {
-        await compile(PWD, NODE_ENV);
+        await compile(CWD, NODE_ENV);
         await dbMigrate();
         exit(0);
       }, rescue);
@@ -193,7 +186,7 @@ export default function CLI() {
     .description('Rollback the last database migration')
     .action(() => {
       return tryCatch(async () => {
-        await compile(PWD, NODE_ENV);
+        await compile(CWD, NODE_ENV);
         await dbRollback();
         exit(0);
       }, rescue);
@@ -204,7 +197,7 @@ export default function CLI() {
     .description('Add fixtures to your db from the seed function')
     .action(() => {
       return tryCatch(async () => {
-        await compile(PWD, NODE_ENV);
+        await compile(CWD, NODE_ENV);
         await dbSeed();
         exit(0);
       }, rescue);

--- a/src/packages/compiler/utils/create-boot-script.js
+++ b/src/packages/compiler/utils/create-boot-script.js
@@ -13,13 +13,14 @@ export default async function createBootScript(dir: string, {
   useStrict: boolean;
 }): Promise<void> {
   let data = template`
-    const { env: { PWD, PORT } } = process;
+    const CWD = process.cwd();
+    const { env: { PORT } } = process;
     const { Application, config, database } = require('./bundle');
 
     module.exports = new Application(
       Object.assign(config, {
         database,
-        path: PWD,
+        path: CWD,
         port: PORT
       })
     );

--- a/src/packages/database/initialize.js
+++ b/src/packages/database/initialize.js
@@ -1,6 +1,8 @@
 // @flow
 import { worker, isMaster } from 'cluster';
 
+import { NODE_ENV } from '../../constants';
+
 import { MigrationsPendingError } from './errors';
 
 import connect from './utils/connect';
@@ -10,8 +12,6 @@ import pendingMigrations from './utils/pending-migrations';
 import type Database from './index';
 import type Logger from '../logger';
 import typeof Model from './model';
-
-const { env: { NODE_ENV = 'development' } } = process;
 
 /**
  * @private

--- a/src/packages/database/utils/connect.js
+++ b/src/packages/database/utils/connect.js
@@ -1,12 +1,12 @@
 import { join as joinPath } from 'path';
 
-import { tryCatchSync } from '../../../utils/try-catch';
-import { ModuleMissingError } from '../../../errors';
-
+import { NODE_ENV } from '../../../constants';
 import { VALID_DRIVERS } from '../constants';
-import { InvalidDriverError } from '../errors';
 
-const { env: { NODE_ENV = 'development' } } = process;
+import { tryCatchSync } from '../../../utils/try-catch';
+
+import { ModuleMissingError } from '../../../errors';
+import { InvalidDriverError } from '../errors';
 
 export default function connect(path, config = {}) {
   let knex;

--- a/src/packages/logger/index.js
+++ b/src/packages/logger/index.js
@@ -3,11 +3,10 @@ import moment from 'moment';
 import { dim, red, yellow } from 'chalk';
 import { isMaster, isWorker } from 'cluster';
 
+import { NODE_ENV } from '../../constants';
 import initialize from './initialize';
 
 import type { PassThrough } from 'stream';
-
-const { env: { NODE_ENV = 'development' } } = process;
 
 /**
  * The `Logger` class is responsible for logging messages from an application

--- a/src/packages/logger/initialize.js
+++ b/src/packages/logger/initialize.js
@@ -3,12 +3,11 @@ import { PassThrough } from 'stream';
 import { createWriteStream } from 'fs';
 import { join as joinPath } from 'path';
 
+import { NODE_ENV } from '../../constants';
 import AnsiRemover from './ansi-remover';
 import fs, { exists } from '../fs';
 
 import type Logger from './index';
-
-const { env: { NODE_ENV = 'development' } } = process;
 
 /**
  * @private

--- a/src/packages/pm/cluster/index.js
+++ b/src/packages/pm/cluster/index.js
@@ -5,12 +5,11 @@ import { EventEmitter } from 'events';
 import { join as joinPath } from 'path';
 import { red, green } from 'chalk';
 
+import { NODE_ENV } from '../../../constants';
 import range from '../../../utils/range';
 
 import type { Worker } from 'cluster';
 import type Logger from '../../logger';
-
-const { env: { NODE_ENV = 'development' } } = process;
 
 /**
  * @private
@@ -82,7 +81,6 @@ class Cluster extends EventEmitter {
       if (this.workers.size < this.maxWorkers) {
         const worker = cluster.fork({
           NODE_ENV,
-          PWD: this.path,
           PORT: this.port
         });
 


### PR DESCRIPTION
In order to ensure cross platform compatibility we should use `process.cwd()` instead of `process.env.PWD`.

This PR also moves `ENV` vars to a central `constants.js` file at the root of the `./src` dir where values are normalized and exported for use throughout the project.