### PR TITLE
feat: do not cluster by default use -c || --cluster

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -70,7 +70,7 @@ cli
   .command('b')
   .alias('build')
   .description('Build your application')
-  .option('--use-weak', 'Use weak mode')
+  .option('-w, --use-weak', 'Use weak mode')
   .action(({ useWeak }) => {
     exec('build', !useWeak)
       .then(exit)
@@ -83,16 +83,17 @@ cli
   .description('Serve your application')
   .option('-e, --environment [env]', '(Default: development)', 'development')
   .option('-p, --port [port]', '(Default: 4000)', parseInt)
-  .option('--hot', 'Reload when a file change is detected')
-  .option('--use-weak', 'Use weak mode')
-  .action(({ hot, port, environment, useWeak }) => {
+  .option('-c, --cluster', 'Run in cluster mode')
+  .option('-H, --hot', 'Reload when a file change is detected')
+  .option('-w, --use-weak', 'Use weak mode')
+  .action(({ hot, port, cluster, environment, useWeak }) => {
     const useStrict = !useWeak;
 
     process.env.PORT = port;
     process.env.NODE_ENV = environment;
 
     exec('build', useStrict)
-      .then(() => exec('serve', { hot, useStrict }))
+      .then(() => exec('serve', { hot, cluster, useStrict }))
       .catch(rescue);
   });
 
@@ -119,7 +120,7 @@ cli
 cli
   .command('db:create')
   .description('Create your database schema')
-  .option('--use-weak', 'Use weak mode')
+  .option('-w, --use-weak', 'Use weak mode')
   .action(({ useWeak }) => {
     exec('build', !useWeak)
       .then(() => exec('dbcreate'))
@@ -130,7 +131,7 @@ cli
 cli
   .command('db:drop')
   .description('Drop your database schema')
-  .option('--use-weak', 'Use weak mode')
+  .option('-w, --use-weak', 'Use weak mode')
   .action(({ useWeak }) => {
     exec('build', !useWeak)
       .then(() => exec('dbdrop'))
@@ -141,7 +142,7 @@ cli
 cli
   .command('db:reset')
   .description('Drop your database schema and create a new schema')
-  .option('--use-weak', 'Use weak mode')
+  .option('-w, --use-weak', 'Use weak mode')
   .action(({ useWeak }) => {
     exec('build', !useWeak)
       .then(() => exec('dbdrop'))
@@ -153,7 +154,7 @@ cli
 cli
   .command('db:migrate')
   .description('Run database migrations')
-  .option('--use-weak', 'Use weak mode')
+  .option('-w, --use-weak', 'Use weak mode')
   .action(({ useWeak }) => {
     exec('build', !useWeak)
       .then(() => exec('dbmigrate'))
@@ -164,7 +165,7 @@ cli
 cli
   .command('db:rollback')
   .description('Rollback the last database migration')
-  .option('--use-weak', 'Use weak mode')
+  .option('-w, --use-weak', 'Use weak mode')
   .action(({ useWeak }) => {
     exec('build', !useWeak)
       .then(() => exec('dbrollback'))
@@ -175,7 +176,7 @@ cli
 cli
   .command('db:seed')
   .description('Add fixtures to your db from the seed function')
-  .option('--use-weak', 'Use weak mode')
+  .option('-w, --use-weak', 'Use weak mode')
   .action(({ useWeak }) => {
     exec('build', !useWeak)
       .then(() => exec('dbseed'))

--- a/src/packages/cli/commands/serve.js
+++ b/src/packages/cli/commands/serve.js
@@ -14,10 +14,12 @@ import { build } from './build';
  */
 export async function serve({
   hot = (NODE_ENV === 'development'),
+  cluster = false,
   useStrict = false
 }: {
-  hot: boolean,
-  useStrict: boolean
+  hot: boolean;
+  cluster: boolean;
+  useStrict: boolean;
 }): Promise<void> {
   const logger = await new Logger({
     path: CWD,
@@ -36,7 +38,8 @@ export async function serve({
   createCluster({
     logger,
     path: CWD,
-    port: PORT
+    port: PORT,
+    maxWorkers: cluster ? undefined : 1
   }).once('ready', () => {
     logger.info(`Lux Server listening on port: ${cyan(`${PORT}`)}`);
   });

--- a/src/packages/pm/cluster/index.js
+++ b/src/packages/pm/cluster/index.js
@@ -21,18 +21,20 @@ class Cluster extends EventEmitter {
 
   logger: Logger;
 
-  workers: Set<Worker> = new Set();
+  workers: Set<Worker>;
 
-  maxWorkers: number = os.cpus().length;
+  maxWorkers: number;
 
   constructor({
     path,
     port,
-    logger
+    logger,
+    maxWorkers
   }: {
-    path: string,
-    port: number,
-    logger: Logger
+    path: string;
+    port: number;
+    logger: Logger;
+    maxWorkers?: number;
   }): Cluster {
     super();
 
@@ -53,6 +55,20 @@ class Cluster extends EventEmitter {
 
       logger: {
         value: logger,
+        writable: false,
+        enumerable: true,
+        configurable: false
+      },
+
+      workers: {
+        value: new Set(),
+        writable: false,
+        enumerable: true,
+        configurable: false
+      },
+
+      maxWorkers: {
+        value: maxWorkers || os.cpus().length,
         writable: false,
         enumerable: true,
         configurable: false

--- a/src/packages/pm/index.js
+++ b/src/packages/pm/index.js
@@ -9,15 +9,18 @@ import type Logger from '../logger';
 export function createCluster({
   path,
   port,
-  logger
+  logger,
+  maxWorkers
 }: {
-  path: string,
-  port: number,
-  logger: Logger
+  path: string;
+  port: number;
+  logger: Logger;
+  maxWorkers?: number;
 }): Cluster {
   return new Cluster({
     path,
     port,
-    logger
+    logger,
+    maxWorkers
   });
 }


### PR DESCRIPTION
Some users may want to manage concurrency on their own through docker containers or something similar. This PR disables default clustering and moves it to a `-c (--cluster)` flag for `lux serve`.