### PR TITLE
fix: fixes #187 issue with class name generation with multiple dashes

### DIFF
--- a/src/packages/cli/templates/application.js
+++ b/src/packages/cli/templates/application.js
@@ -2,12 +2,13 @@
 import { classify } from 'inflection';
 
 import template from '../../template';
+import underscore from '../../../utils/underscore';
 
 /**
  * @private
  */
 export default (name: string): string => {
-  name = classify(name.replace('-', '_'));
+  name = classify(underscore(name));
 
   return template`
     import { Application } from 'lux-framework';


### PR DESCRIPTION
Fixes an issue where generating a new app with multiple dashes in the app name will cause the output of the classname to have a dash in it.  Previously only the first dash was removed, the rest were kept.  This results in a syntax error and fails to start the app up.