### PR TITLE
feat: return a promise from relationships

### DIFF
--- a/src/packages/database/model/index.js
+++ b/src/packages/database/model/index.js
@@ -12,6 +12,8 @@ import omit from '../../../utils/omit';
 import entries from '../../../utils/entries';
 import underscore from '../../../utils/underscore';
 
+import type { options as relationshipOptions } from '../related/interfaces';
+
 class Model {
   /**
    * @private
@@ -535,6 +537,13 @@ class Model {
     return Boolean(this.scopes[name]);
   }
 
+  /**
+   * Check if a value is an instance of a Model.
+   */
+  static isInstance(obj: mixed): boolean {
+    return obj instanceof this;
+  }
+
   static columnFor(key): Object {
     const {
       attributes: {
@@ -553,7 +562,7 @@ class Model {
     }
   }
 
-  static relationshipFor(key): Object {
+  static relationshipFor(key): relationshipOptions {
     const {
       relationships: {
         [key]: relationship

--- a/src/packages/database/relationship/index.js
+++ b/src/packages/database/relationship/index.js
@@ -1,0 +1,82 @@
+// @flow
+import { camelize } from 'inflection';
+
+import relatedFor from './utils/related-for';
+
+import type Model from '../model';
+
+export async function get(
+  owner: Model,
+  key: string
+): Array<Model> | ?Model {
+  const options = owner.constructor.relationshipFor(key);
+  let relationship;
+
+  const {
+    type,
+    model
+  } = options;
+
+  if (model) {
+    const related = relatedFor(owner);
+    let { foreignKey } = options;
+
+    foreignKey = camelize(foreignKey, true);
+    relationship = related.get(key);
+
+    if (!relationship) {
+      switch (type) {
+        case 'hasOne':
+        case 'hasMany':
+          relationship = model.where({
+            [foreignKey]: owner[owner.constructor.primaryKey]
+          });
+
+          if (type === 'hasOne') {
+            relationship = relationship.first();
+          }
+
+          relationship = await relationship;
+          break;
+
+        case 'belongsTo':
+          const foreignVal = owner[foreignKey];
+
+          if (foreignVal) {
+            relationship = await model.find(foreignVal);
+          }
+          break;
+      }
+
+      set(owner, key, relationship);
+    }
+  }
+
+  return relationship;
+}
+
+export function set(
+  owner: Model,
+  key: string,
+  val: Array<Model> | ?Model
+): void {
+  const { type, model } = owner.constructor.relationshipFor(key);
+  const related = relatedFor(owner);
+
+  switch (type) {
+    case 'hasMany':
+      if (Array.isArray(val)) {
+        related.set(key, val);
+      }
+      break;
+
+    case 'hasOne':
+    case 'belongsTo':
+      if (val && typeof val === 'object' && !model.isInstance(val)) {
+        val = new model(val);
+      }
+
+      related.set(key, val);
+      break;
+  }
+}

--- a/src/packages/database/relationship/interfaces.js
+++ b/src/packages/database/relationship/interfaces.js
@@ -1,0 +1,9 @@
+// @flow
+import type Model from '../model';
+
+export type options = {
+  type: 'hasOne' | 'hasMany' | 'belongsTo';
+  model: Model;
+  inverse: string;
+  foreignKey: string;
+};

--- a/src/packages/database/relationship/utils/related-for.js
+++ b/src/packages/database/relationship/utils/related-for.js
@@ -1,0 +1,15 @@
+// @flow
+import type Model from '../../model';
+
+const REFS: WeakMap<Model, Map<string, Model>> = new WeakMap();
+
+export default function relatedFor(owner: Model): Map<string, Model> {
+  let related = REFS.get(owner);
+
+  if (!related) {
+    related = new Map();
+    REFS.set(owner, related);
+  }
+
+  return related;
+}

--- a/src/utils/uniq.js
+++ b/src/utils/uniq.js
@@ -1,0 +1,25 @@
+// @flow
+
+/**
+ * @private
+ */
+export default function uniq(
+  source: Array<any>,
+  ...keys: Array<string>
+): Array<any> {
+  const hasKeys = Boolean(keys.length);
+
+  return source.filter((x, xIdx, arr) => {
+    let lastIdx;
+
+    if (hasKeys) {
+      lastIdx = arr.findIndex((y, yIdx) => {
+        return yIdx > xIdx || keys.every(key => x[key] === y[key]);
+      });
+    } else {
+      lastIdx = source.lastIndexOf(x);
+    }
+
+    return xIdx === lastIdx;
+  });
+}


### PR DESCRIPTION
Models now return a `Promise` when accessing a relationship. If the related record have been eager loaded with includes it will immediately resolve to the eager loaded value. Otherwise, it will load the related records from the database and resolve with the result.

##### Example

*Async/Await*
```javascript
const post = await Post.find(1);

console.log(await post.author);
// => Author {}
```

*Promises*
```javascript
Post.find(1)
  .then(post => post.author)
  .then(author => console.log(author));
// => Author {}
```

--

Closes #181