### PR TITLE
fix: display correct error messages from flow script

### DIFF
--- a/scripts/flow.js
+++ b/scripts/flow.js
@@ -7,12 +7,7 @@ const platform = require('os').platform();
 
 if (!WINDOWS.test(platform)) {
   exec('flow check', (err, data) => {
-    if (err) {
-      console.error(err);
-      process.exit(1);
-    } else {
-      console.log(data);
-      process.exit(0);
-    }
+    console.log(data);
+    process.exit(err ? 1 : 0);
   });
 }


### PR DESCRIPTION
This PR ensures you will get the output from a failed `npm run flow` cmd.