### PR TITLE
Errors should be a top level member

### DIFF
--- a/src/packages/server/responder/utils/data-for.js
+++ b/src/packages/server/responder/utils/data-for.js
@@ -26,9 +26,7 @@ export default function dataFor(
     }
 
     return {
-      data: {
-        errors: [errData]
-      }
+      errors: [errData]
     };
   }
 }


### PR DESCRIPTION
According to the JSON API spec, `errors` should be a top level document (http://jsonapi.org/format/#document-top-level).
Currently when an error is returned, it is included in the `data` top level member. This patch fixes this behaviour.