### PR TITLE
Resource IDs must be strings

### DIFF
--- a/src/packages/serializer/index.js
+++ b/src/packages/serializer/index.js
@@ -407,13 +407,13 @@ class Serializer {
     }
 
     let serialized: {
-      id: number,
+      id: string,
       type: string,
       links?: Object,
       attributes: Object,
       relationships?: Object
     } = {
-      id,
+      id: id.toString(),
       type,
       attributes
     };
@@ -519,7 +519,7 @@ class Serializer {
 
     return {
       data: {
-        id,
+        id: id.toString(),
         type
       },
 

--- a/src/packages/server/responder/utils/data-for.js
+++ b/src/packages/server/responder/utils/data-for.js
@@ -26,9 +26,7 @@ export default function dataFor(
     }
 
     return {
-      data: {
-        errors: [errData]
-      }
+      errors: [errData]
     };
   }
 }

--- a/test/integration/serializer.js
+++ b/test/integration/serializer.js
@@ -19,7 +19,7 @@ describe('Integration: class Serializer', () => {
   it('serializes id', () => {
     const { data: { id } } = subject;
 
-    expect(id).to.equal(1);
+    expect(id).to.equal('1');
   });
 
   it('serializes attributes', () => {


### PR DESCRIPTION
According to the spec (http://jsonapi.org/format/#document-resource-object-identification), the value of the resource object identifiers `id` field should be a string.