### PR TITLE
Deduce domain protocol from connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inflection": "1.10.0",
     "moment": "2.14.1",
     "ora": "0.2.3",
-    "rollup": "0.33.2",
+    "rollup": "0.34.0",
     "rollup-plugin-alias": "1.2.0",
     "rollup-plugin-babel": "2.6.1",
     "rollup-plugin-eslint": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "ansi-regex": "2.0.0",
-    "babel-eslint": "6.1.1",
+    "babel-eslint": "6.1.2",
     "bluebird": "3.4.1",
     "chalk": "1.1.3",
     "commander": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "ansi-regex": "2.0.0",
-    "babel-eslint": "6.1.2",
+    "babel-eslint": "6.1.1",
     "bluebird": "3.4.1",
     "chalk": "1.1.3",
     "commander": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inflection": "1.10.0",
     "moment": "2.14.1",
     "ora": "0.2.3",
-    "rollup": "0.34.0",
+    "rollup": "0.34.1",
     "rollup-plugin-alias": "1.2.0",
     "rollup-plugin-babel": "2.6.1",
     "rollup-plugin-eslint": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inflection": "1.10.0",
     "moment": "2.14.1",
     "ora": "0.2.3",
-    "rollup": "0.34.1",
+    "rollup": "0.33.2",
     "rollup-plugin-alias": "1.2.0",
     "rollup-plugin-babel": "2.6.1",
     "rollup-plugin-eslint": "2.0.2",

--- a/src/packages/route/utils/create-action.js
+++ b/src/packages/route/utils/create-action.js
@@ -62,10 +62,15 @@ export default function createAction(
         params: {
           page,
           include
+        },
+
+        connection: {
+          encrypted
         }
       } = req;
 
-      const domain = `http://${headers.get('host')}`;
+      const protocol = encrypted ? 'https' : 'http';
+      const domain = `${protocol}://${headers.get('host')}`;
 
       let total;
       let { params: { fields } } = req;


### PR DESCRIPTION
Currently, the domain protocol is hardcoded to http. The `encrypted` attribute is set in the request's `connection` when the request is made via HTTPS.
We should use this information to correctly deduce the used protocol.