### PR TITLE
Logger Minutes should be double digits

### DIFF
--- a/src/packages/logger/index.js
+++ b/src/packages/logger/index.js
@@ -103,7 +103,7 @@ class Logger {
    * @private
    */
   get timestamp(): string {
-    return moment().format('M/D/YY h:m:ss A');
+    return moment().format('M/D/YY h:mm:ss A');
   }
 
   /**


### PR DESCRIPTION
Fixes a minor display issue where the minutes if they are in the single digits, only displays a single digit.