### PR TITLE
fix: empty 'fields' params cause all keys of a resource to be exposed

### DIFF
--- a/src/packages/database/model/index.js
+++ b/src/packages/database/model/index.js
@@ -410,10 +410,6 @@ class Model {
   }
 
   getAttributes(...keys: Array<string>): Object {
-    if (!keys.length) {
-      keys = this.constructor.attributeNames;
-    }
-
     return setType(() => pick(this, ...keys));
   }
 


### PR DESCRIPTION
Closes #269 