### PR TITLE
Feat: Added default fallback for CLI

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -18,6 +18,7 @@ const PROJECT_REQUIRED = [
 
 const cli = require('commander');
 const path = require('path');
+const { red, green } = require('chalk');
 
 function inLuxProject() {
   if (PWD.indexOf(path.join('lux', 'test', 'test-app')) >= 0) {
@@ -30,6 +31,14 @@ function inLuxProject() {
       return false;
     }
   }
+}
+
+function commandNotFound(cmd) {
+  console.log();
+  console.log(`  ${red(cmd)} isn't a valid command`);
+  console.log();
+  console.log(`  Type ${green('lux --help')} for a full list of commands`);
+  console.log();
 }
 
 function exec(cmd, ...args) {
@@ -230,6 +239,11 @@ cli
       .then(() => exec('dbseed'))
       .then(exit)
       .catch(rescue);
+  });
+
+cli
+  .on('*', (cmd) => {
+    commandNotFound(cmd)
   });
 
 cli.parse(process.argv);

--- a/bin/lux
+++ b/bin/lux
@@ -18,6 +18,7 @@ const PROJECT_REQUIRED = [
 
 const cli = require('commander');
 const path = require('path');
+const { EOL } = require('os');
 const { red, green } = require('chalk');
 
 function inLuxProject() {
@@ -34,11 +35,8 @@ function inLuxProject() {
 }
 
 function commandNotFound(cmd) {
-  console.log();
-  console.log(`  ${red(cmd)} isn't a valid command`);
-  console.log();
-  console.log(`  Type ${green('lux --help')} for a full list of commands`);
-  console.log();
+  console.log(`${EOL}  ${red(cmd)} is not a valid command${EOL}`);
+  console.log(`  Use ${green('lux --help')} for a full list of commands${EOL}`);
 }
 
 function exec(cmd, ...args) {


### PR DESCRIPTION
Addresses https://github.com/postlight/lux/issues/263

I considered automatically printing the help after the error message, but I decided it would get annoying to see the whole error message if you just entered a typo. It also made it more difficult to focus in on the fact that there _was_ and error in the first place. So I went with this.

I pulled in chalk, since you're using it elsewhere, but if you don't like it, I can remove it!

Last: In an ideal world, we'd look at the text of the command and see if it's close to an existing lux command and present that to the user, like a "did you mean..." — but I'm trying to avoid letting this creep too far for a simple feature addition. 😄 