### PR TITLE
Allow the use of urls for databases to connect

### DIFF
--- a/src/packages/database/utils/connect.js
+++ b/src/packages/database/utils/connect.js
@@ -16,6 +16,7 @@ export default function connect(path, config = {}) {
   let { pool } = config;
 
   const {
+    url,
     host,
     socket,
     driver,
@@ -43,22 +44,23 @@ export default function connect(path, config = {}) {
 
   const usingSQLite = driver === 'sqlite3';
 
+  const connection = (url) ? url : {
+    host,
+    database,
+    password,
+    user: username,
+    socketPath: socket,
+
+    filename: usingSQLite ?
+      joinPath(path, 'db', `${database}_${NODE_ENV}.sqlite`)
+      : undefined
+  };
+
   return knex({
     pool,
     debug: false,
     client: driver,
-    useNullAsDefault: usingSQLite,
-
-    connection: {
-      host,
-      database,
-      password,
-      user: username,
-      socketPath: socket,
-
-      filename: usingSQLite ?
-        joinPath(path, 'db', `${database}_${NODE_ENV}.sqlite`)
-        : undefined
-    }
+    connection,
+    useNullAsDefault: usingSQLite
   });
 }


### PR DESCRIPTION
This is not a solution for https://github.com/postlight/lux/issues/288, but it just adds support for using direct urls. You still have to define the `database`-name in the config, because this is used by other parts of the framework.

> NOTE: This is definitely a WIP. Can someone point me to the place where I best could parse the url of postgresql to make the `database`-name available?