### PR TITLE
Fix: Lining up stats in debug logger when ms length differs

### DIFF
--- a/src/packages/logger/request-logger/templates.js
+++ b/src/packages/logger/request-logger/templates.js
@@ -44,10 +44,10 @@ ${stats.map(({ type, name, duration, controller }) => {
     name = `${yellow(controller)}#${name}`;
   }
 
-  return `${pad(endTime, startTime, duration)} ms ${name}`;
+  return `${pad(startTime, endTime, duration)} ms ${name}`;
 }).join('\n')}
-${pad(endTime,
-      startTime,
+${pad(startTime,
+      endTime,
       stats.reduce((total, { duration }) => total + duration, 0))} ms Total
 ${(endTime - startTime).toString()} ms Actual\
 `;
@@ -83,16 +83,15 @@ Processed ${cyan(`${method}`)} "${path}" ${magenta('Params')} ${
 /**
  * @private
  */
-const pad = (endTime, startTime, duration) => {
-  const maxLength = (endTime - startTime).toString().length;
-  let padNum = maxLength - duration.toString().length;
+function countDigits(num: number) {
+  return Math.floor(Math.log10(num) + 1);
+}
 
-  let padding = '';
+/**
+ * @private
+ */
+function pad(startTime: number, endTime: number, duration: number) {
+  const maxLength = countDigits(endTime - startTime);
 
-  while (padNum > 0) {
-    padding += ' ';
-    padNum--;
-  }
-
-  return padding + duration;
-};
+  return ' '.repeat(maxLength - countDigits(duration)) + duration;
+}

--- a/src/packages/logger/request-logger/templates.js
+++ b/src/packages/logger/request-logger/templates.js
@@ -44,9 +44,11 @@ ${stats.map(({ type, name, duration, controller }) => {
     name = `${yellow(controller)}#${name}`;
   }
 
-  return `${duration >= 10 ? duration : ` ${duration}`} ms ${name}`;
+  return `${pad(endTime, startTime, duration)} ms ${name}`;
 }).join('\n')}
-${stats.reduce((total, { duration }) => total + duration, 0)} ms Total
+${pad(endTime,
+      startTime,
+      stats.reduce((total, { duration }) => total + duration, 0))} ms Total
 ${(endTime - startTime).toString()} ms Actual\
 `;
 
@@ -77,3 +79,20 @@ Processed ${cyan(`${method}`)} "${path}" ${magenta('Params')} ${
   : null
 }
 `;
+
+/**
+ * @private
+ */
+const pad = (endTime, startTime, duration) => {
+  const maxLength = (endTime - startTime).toString().length;
+  let padNum = maxLength - duration.toString().length;
+
+  let padding = '';
+
+  while (padNum > 0) {
+    padding += ' ';
+    padNum--;
+  }
+
+  return padding + duration
+}

--- a/src/packages/logger/request-logger/templates.js
+++ b/src/packages/logger/request-logger/templates.js
@@ -94,5 +94,5 @@ const pad = (endTime, startTime, duration) => {
     padNum--;
   }
 
-  return padding + duration
-}
+  return padding + duration;
+};


### PR DESCRIPTION
Addresses #259. I'm very open to criticism here. This works, and should work even when the number of digits varies significantly. E.g., 

```
Stats

  4 ms TagsController#show
 24 ms Total
378 ms Actual
```

It operates on the assumption that the actual time will always be the longest (which... should be the case, correct?). I don't love that the pad function has to calculate the maxLength multiple times, but it seemed necessary given the current state of the template function, and I didn't want to change that too much. 

But yeah, open to suggestions.