### PR TITLE
Feat: aliased app dir for easier imports

### DIFF
--- a/src/packages/compiler/index.js
+++ b/src/packages/compiler/index.js
@@ -80,7 +80,8 @@ export async function compile(dir: string, env: string, {
 
     plugins: [
       alias({
-        LUX_LOCAL: local.replace(BACKSLASH, '/')
+        LUX_LOCAL: local.replace(BACKSLASH, '/'),
+        app: path.join(dir, 'app')
       }),
 
       json(),


### PR DESCRIPTION
Addresses https://github.com/postlight/lux/issues/272

The documentation for rollup-plugin-alias isn't great, but this appears to be the correct usage. I tested it in the social-network example app and the test-app and it's working as expected.