### PR TITLE
fix: pad function is failing due to negative values

### DIFF
--- a/src/packages/logger/request-logger/templates.js
+++ b/src/packages/logger/request-logger/templates.js
@@ -84,7 +84,9 @@ Processed ${cyan(`${method}`)} "${path}" ${magenta('Params')} ${
  * @private
  */
 function countDigits(num: number) {
-  return Math.floor(Math.log10(num) + 1);
+  const digits = Math.floor(Math.log10(num) + 1);
+
+  return digits > 0 && Number.isFinite(digits) ? digits : 1;
 }
 
 /**


### PR DESCRIPTION
Closes #294 

--

Turns out, the number `Infinity` was causing this bug.