### PR TITLE
Fix: id null check fails if using postgres

### DIFF
--- a/examples/social-network/app/models/user.js
+++ b/examples/social-network/app/models/user.js
@@ -43,7 +43,7 @@ class User extends Model {
     async beforeSave(user) {
       const { id, password, dirtyAttributes } = user;
 
-      if (!id && password || dirtyAttributes.has('password')) {
+      if ((typeof id !== 'number') && password || dirtyAttributes.has('password')) {
         const salt = generateSalt();
 
         assign(user, {


### PR DESCRIPTION
I looked into the reason this `beforeSave` hook was failing on postgres, per #306, and here's what I found:

The original code in the hook is doing a check to see if `id` is `null`, which fits with the sqlite3 driver, but when using postgres id isn't null—it's a string that looks like `nextval('users_id_seq'::regclass)`. 

For the purpose of checking/fixing in the social-network example, I'm doing a typeof check on id since the id of a saved model should be a number, which works, but it seems like maybe there's an underlying issue here: 

It seems like the id check you're doing here is intended to determine whether or not a model has been persisted to the database, and I'm wondering if this a feature you might want to add—sort of like [persisted?](http://apidock.com/rails/ActiveRecord/Persistence/persisted%3F) or [new_record?](http://apidock.com/rails/ActiveRecord/Persistence/persisted%3F) in Rails.

Thoughts?