### PR TITLE
Allow inverse to default to owner if not passed

### DIFF
--- a/src/packages/database/model/initialize-class.js
+++ b/src/packages/database/model/initialize-class.js
@@ -224,7 +224,10 @@ export default async function initializeClass<T: Class<Model>>({
     }, {});
 
   const belongsTo = entries(model.belongsTo || {})
-    .reduce((hash, [relatedName, { inverse, model: relatedModel }]) => {
+    .reduce((hash, [relatedName, {
+      inverse=camelize(pluralize(model.name), true),
+      model: relatedModel
+    }]) => {
       const relationship = {};
 
       Object.defineProperties(relationship, {
@@ -264,7 +267,10 @@ export default async function initializeClass<T: Class<Model>>({
     }, {});
 
   const hasOne = entries(model.hasOne || {})
-    .reduce((hash, [relatedName, { inverse, model: relatedModel }]) => {
+    .reduce((hash, [relatedName, {
+      inverse=camelize(model.name, true),
+      model: relatedModel
+    }]) => {
       const relationship = {};
 
       Object.defineProperties(relationship, {
@@ -305,7 +311,7 @@ export default async function initializeClass<T: Class<Model>>({
 
   const hasMany = entries(model.hasMany || {})
     .reduce((hash, [relatedName, {
-      inverse,
+      inverse=camelize(model.name, true),
       through, model: relatedModel
     }]) => {
       const relationship = {};


### PR DESCRIPTION
@zacharygolba looking for your thoughts on a change like this. This is a pretty small change to allow for default inverses. I found in most places I'm writing models that aren't aliasing the model to another name, so the inverse property is almost always the owner model. 

Example:
```
import { Model } from 'lux-framework';

class Job extends Model {
  static belongsTo = {
    configurationName: {
      model: 'configuration-name',
      inverse: 'jobs'
    },
    operatingSystem: {
      model: 'operating-system',
      inverse: 'jobs'
    },
    testSuite: {
      model: 'test-suite',
      inverse: 'jobs'
    },
    product: {
      model: 'product',
      inverse: 'jobs'
    },
    applicationStack: {
      model: 'application-stack',
      inverse: 'jobs'
    }
  };
}

export default Job;
```

This change would allow you to omit the `inverse` property if it's just the owner model, which would allow:
```
import { Model } from 'lux-framework';

class Job extends Model {
  static belongsTo = {
    configurationName: {
      model: 'configuration-name'
    },
    operatingSystem: {
      model: 'operating-system'
    },
    testSuite: {
      model: 'test-suite'
    },
    product: {
      model: 'product'
    },
    applicationStack: {
      model: 'application-stack'
    }
  };
}

export default Job;
```

Or even with your fix to model casing (which I had not updated to yet), it would be even simpler for defaults (while still allowing you to specify model and inverse if your schema requires it):
```
import { Model } from 'lux-framework';

class Job extends Model {
  static belongsTo = {
    configurationName: {},
    operatingSystem: {},
    testSuite: {},
    product: {},
    applicationStack: {}
  };
}

export default Job;
```
