### PR TITLE
feat: add #distinct() query method

### DIFF
--- a/src/packages/database/model/index.js
+++ b/src/packages/database/model/index.js
@@ -561,6 +561,10 @@ class Model {
     return new Query(this).select(...params);
   }
 
+  static distinct(...params: Array<string>) {
+    return new Query(this).distinct(...params);
+  }
+
   static include(...relationships: Array<Object|string>) {
     return new Query(this).include(...relationships);
   }

--- a/src/packages/database/query/index.js
+++ b/src/packages/database/query/index.js
@@ -263,6 +263,14 @@ class Query {
     return this;
   }
 
+  distinct(...attrs: Array<string>) {
+    if (!this.shouldCount) {
+      this.snapshots.push(['distinct', formatSelect(this.model, attrs)]);
+    }
+
+    return this.select();
+  }
+
   include(...relationships: Array<Object|string>) {
     let included;
 

--- a/src/packages/serializer/index.js
+++ b/src/packages/serializer/index.js
@@ -369,7 +369,7 @@ class Serializer {
     formatRelationships?: boolean
   }): Promise<JSONAPI$ResourceObject> {
     const { resourceName: type } = item;
-    const id = item.getPrimaryKey().toString();
+    const id = String(item.getPrimaryKey());
     let relationships = {};
 
     const attributes = dasherizeKeys(
@@ -452,7 +452,7 @@ class Serializer {
     included: Array<JSONAPI$ResourceObject>;
   }): Promise<JSONAPI$RelationshipObject> {
     const { resourceName: type, constructor: { serializer } } = item;
-    const id = item.getPrimaryKey().toString();
+    const id = String(item.getPrimaryKey());
 
     if (include) {
       included.push(


### PR DESCRIPTION
This PR adds a chainable `#distinct()` method to the query interface.

#### Usage

```javascript
import Post from 'app/models/post';

Post.distinct('title' /*, 'body', ...etc */).where({
  isPublic: true
});

// SELECT DISTINCT "posts"."title" AS "title" FROM "posts" WHERE "posts"."is_public" = TRUE
```

--

Closes #332 