### PR TITLE
fix: model migration table name includes filename

### DIFF
--- a/src/packages/cli/templates/model-migration.js
+++ b/src/packages/cli/templates/model-migration.js
@@ -3,6 +3,7 @@ import { pluralize } from 'inflection';
 
 import template from '../../template';
 
+import chain from '../../../utils/chain';
 import indent from '../utils/indent';
 import underscore from '../../../utils/underscore';
 
@@ -10,8 +11,12 @@ import underscore from '../../../utils/underscore';
  * @private
  */
 export default (name: string, attrs: Array<string> | string): string => {
-  const table = pluralize(underscore(name));
   const indices = ['id'];
+  const table = chain(name)
+    .pipe(str => str.substr(24))
+    .pipe(underscore)
+    .pipe(pluralize)
+    .value();
 
   if (!attrs) {
     attrs = [];


### PR DESCRIPTION
Fixes a bug where newly generated migrations contain the full filename rather than just the table name.