### PR TITLE
chore: switch to bcryptjs instead of native bcrypt in social-network …

### DIFF
--- a/examples/social-network/app/models/user.js
+++ b/examples/social-network/app/models/user.js
@@ -1,5 +1,6 @@
 import { Model } from 'lux-framework';
-import bcrypt from 'bcrypt-as-promised';
+
+import { hashPassword, comparePassword } from 'app/utils/password';
 
 class User extends Model {
   static hasMany = {
@@ -35,7 +36,7 @@ class User extends Model {
   static hooks = {
     async beforeSave(user) {
       if (user.isNew || user.dirtyAttributes.has('password')) {
-        user.password = await bcrypt.hash(user.password, 10);
+        user.password = await hashPassword(user.password);
       }
     }
   };
@@ -58,10 +59,9 @@ class User extends Model {
     const user = await this.findByEmail(email);
 
     if (user) {
-      return await bcrypt
-        .compare(password, user.password)
-        .then(() => user)
-        .catch(bcrypt.MISMATCH_ERROR, () => false);
+      const isAuthenticated = await comparePassword(password, user.password);
+
+      return isAuthenticated && user;
     }
   }
 }

--- a/examples/social-network/app/utils/password.js
+++ b/examples/social-network/app/utils/password.js
@@ -1,0 +1,25 @@
+import bcrypt from 'bcryptjs';
+
+export function hashPassword(password) {
+  return new Promise((resolve, reject) => {
+    bcrypt.hash(password, 10, (err, hash) => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve(hash);
+    });
+  });
+}
+
+export function comparePassword(password, hash) {
+  return new Promise((resolve, reject) => {
+    bcrypt.compare(password, hash, (err, result) => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve(result);
+    });
+  });
+}

--- a/examples/social-network/package.json
+++ b/examples/social-network/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "babel-core": "6.14.0",
     "babel-preset-lux": "1.2.0",
-    "bcrypt-as-promised": "1.1.0",
+    "bcryptjs": "2.3.0",
     "knex": "0.11.10",
     "lux-framework": "1.0.0-rc.7",
     "sqlite3": "3.1.4"


### PR DESCRIPTION
This PR removes [`brcrypt-as-promised`](https://github.com/iceddev/bcrypt-as-promised) in favor of [`bcryptjs`](https://github.com/dcodeIO/bcrypt.js). [`brcrypt-as-promised`](https://github.com/iceddev/bcrypt-as-promised) has a dependency that requires C++ to be compiled which is undesirable for Windows as it requires downloading a few GB of libraries.