### PR TITLE
fix: use path.sep to resolve root tmp dirs in fs tests

### DIFF
--- a/src/packages/fs/test/fs.test.js
+++ b/src/packages/fs/test/fs.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { join } from 'path';
+import { sep, join } from 'path';
 
 import { expect } from 'chai';
 import { it, describe, before, after, beforeEach, afterEach } from 'mocha';
@@ -162,7 +162,7 @@ describe('module "fs"', () => {
   });
 
   describe('#watch()', () => {
-    const watchPath = join('tmp', `lux-${Date.now()}`);
+    const watchPath = join(sep, 'tmp', `lux-${Date.now()}`);
     let result;
 
     before(async () => {

--- a/src/packages/fs/test/watcher.test.js
+++ b/src/packages/fs/test/watcher.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { join as joinPath } from 'path';
+import { sep, join as joinPath } from 'path';
 
 import { expect } from 'chai';
 import { it, describe, after, before } from 'mocha';
@@ -10,7 +10,7 @@ import { APPVEYOR } from '../../../constants';
 import { rmrf, mkdirRec, writeFile } from '../index';
 
 describe('module "fs"', () => {
-  const tmpDirPath = joinPath('tmp', `lux-${Date.now()}`);
+  const tmpDirPath = joinPath(sep, 'tmp', `lux-${Date.now()}`);
   const tmpAppPath = joinPath(tmpDirPath, 'app');
 
   before(async () => {


### PR DESCRIPTION
This PR prevents relative `tmp` dirs from being used in `fs` tests.