### PR TITLE
feat: add after-action middleware hook to controller

### DIFF
--- a/src/packages/application/utils/create-controller.js
+++ b/src/packages/application/utils/create-controller.js
@@ -59,6 +59,11 @@ export default function createController<T: Controller>(
       ...parent.beforeAction.map(fn => fn.bind(parent)),
       ...instance.beforeAction.map(fn => fn.bind(instance))
     ];
+
+    instance.afterAction = [
+      ...instance.afterAction.map(fn => fn.bind(instance)),
+      ...parent.afterAction.map(fn => fn.bind(parent))
+    ];
   }
 
   Reflect.defineProperty(instance, 'parent', {
@@ -73,6 +78,7 @@ export default function createController<T: Controller>(
     'sort',
     'filter',
     'params',
-    'beforeAction'
+    'beforeAction',
+    'afterAction'
   );
 }

--- a/src/packages/controller/index.js
+++ b/src/packages/controller/index.js
@@ -9,7 +9,11 @@ import type { Request, Response } from '../server'; // eslint-disable-line max-l
 import findOne from './utils/find-one';
 import findMany from './utils/find-many';
 import findRelated from './utils/find-related';
-import type { Controller$opts, Controller$Middleware } from './interfaces';
+import type {
+  Controller$opts,
+  Controller$beforeAction,
+  Controller$afterAction
+} from './interfaces';
 
 /**
  * The `Controller` class is responsible for taking in requests from the outside
@@ -124,7 +128,19 @@ class Controller {
    * @memberof Controller
    * @instance
    */
-  beforeAction: Array<Controller$Middleware> = [];
+  beforeAction: Array<Controller$beforeAction> = [];
+
+  /**
+   * Middleware functions to execute on each request handled by a `Controller`.
+   *
+   * Middleware functions declared in afterAction on an `ApplicationController`
+   * will be executed after ALL route handlers.
+   *
+   * @property afterAction
+   * @memberof Controller
+   * @instance
+   */
+  afterAction: Array<Controller$afterAction> = [];
 
   /**
    * The number of records to return for the #index action when a `?limit`
@@ -349,5 +365,6 @@ export { BUILT_IN_ACTIONS } from './constants';
 export type {
   Controller$opts,
   Controller$builtIn,
-  Controller$Middleware,
+  Controller$beforeAction,
+  Controller$afterAction,
 } from './interfaces';

--- a/src/packages/controller/interfaces.js
+++ b/src/packages/controller/interfaces.js
@@ -17,9 +17,15 @@ export type Controller$builtIn =
   | 'update'
   | 'destroy';
 
-export type Controller$Middleware = (
+export type Controller$beforeAction = (
   request: Request,
   response: Response
+) => Promise<any>;
+
+export type Controller$afterAction = (
+  request: Request,
+  response: Response,
+  responseData: any
 ) => Promise<any>;
 
 export type Controller$findOne<T: Model> = (

--- a/src/packages/controller/interfaces.js
+++ b/src/packages/controller/interfaces.js
@@ -5,9 +5,9 @@ import type Serializer from '../serializer';
 import type Controller from './index';
 
 export type Controller$opts = {
-  model: Class<Model>;
-  namespace: string;
-  serializer: Serializer<*>;
+  model?: Class<Model>;
+  namespace?: string;
+  serializer?: Serializer<*>;
 };
 
 export type Controller$builtIn =

--- a/src/packages/router/route/action/enhancers/resource.js
+++ b/src/packages/router/route/action/enhancers/resource.js
@@ -8,7 +8,8 @@ import type { Action } from '../interfaces';
 * @private
 */
 export default function resource(action: Action<any>): Action<any> {
-  return async function resourceAction(req, res) {
+  // eslint-disable-next-line func-names
+  const resourceAction = async function (req, res) {
     const { route: { action: actionName } } = req;
     const result = action(req, res);
     let links = {};
@@ -72,4 +73,10 @@ export default function resource(action: Action<any>): Action<any> {
 
     return data;
   };
+
+  Reflect.defineProperty(resourceAction, 'name', {
+    value: action.name
+  });
+
+  return resourceAction;
 }

--- a/src/packages/router/route/action/enhancers/track-perf.js
+++ b/src/packages/router/route/action/enhancers/track-perf.js
@@ -8,9 +8,11 @@ import type { Action } from '../interfaces';
  * @private
  */
 export default function trackPerf<T, U: Action<T>>(action: U): Action<T> {
-  return async function trackedAction(req, res) {
+  // eslint-disable-next-line func-names
+  const trackedAction = async function (...args: Array<any>) {
+    const [req, res] = args;
     const start = Date.now();
-    const result = await action(req, res);
+    const result = await action(...args);
     let { name } = action;
     let type = 'middleware';
 
@@ -30,4 +32,10 @@ export default function trackPerf<T, U: Action<T>>(action: U): Action<T> {
 
     return result;
   };
+
+  Reflect.defineProperty(trackedAction, 'name', {
+    value: action.name
+  });
+
+  return trackedAction;
 }

--- a/src/packages/router/route/action/index.js
+++ b/src/packages/router/route/action/index.js
@@ -24,10 +24,12 @@ export function createAction(
     // eslint-disable-next-line no-underscore-dangle
     function __FINAL_HANDLER__(req, res) {
       return fn(req, res);
-    }
+    },
+    ...controller.afterAction,
   ].map(trackPerf);
 }
 
+export { FINAL_HANDLER } from './constants';
 export { default as createPageLinks } from './utils/create-page-links';
 
 export type { Action } from './interfaces';

--- a/src/packages/router/route/action/test/track-perf.test.js
+++ b/src/packages/router/route/action/test/track-perf.test.js
@@ -4,12 +4,9 @@ import { it, describe, before } from 'mocha';
 
 import type { Action } from '../../../index';
 import type { Request, Response } from '../../../../server';
+import sleep from '../../../../../utils/sleep';
 import trackPerf from '../enhancers/track-perf';
 import { getTestApp } from '../../../../../../test/utils/get-test-app';
-
-function sleep(amount: number) {
-  return new Promise(resolve => setTimeout(resolve, amount));
-}
 
 describe('module "router/route/action"', () => {
   describe('enhancer trackPerf()', () => {

--- a/src/packages/router/route/test/route.test.js
+++ b/src/packages/router/route/test/route.test.js
@@ -1,49 +1,53 @@
 // @flow
-
+import { spy } from 'sinon';
 import { expect } from 'chai';
 import { it, describe, before } from 'mocha';
 
-import Route from '../index';
-
-import setType from '../../../../utils/set-type';
+import Controller from '../../../controller';
+import type { Request, Response } from '../../../server';
 import { getTestApp } from '../../../../../test/utils/get-test-app';
+import {
+  createResponse,
+  createRequestBuilder
+} from '../../../../../test/utils/mocks';
 
-import type Controller from '../../../controller';
+import Route from '../index';
 
 describe('module "router/route"', () => {
   describe('class Route', () => {
-    let staticRoute: Route;
-    let dynamicRoute: Route;
-    let dataRoute: Route;
-
-    before(async () => {
-      const { controllers } = await getTestApp();
-      const controller: Controller = setType(() => controllers.get('posts'));
-
-      staticRoute = new Route({
-        controller,
-        type: 'collection',
-        path: 'posts',
-        action: 'index',
-        method: 'GET',
-      });
-      dynamicRoute = new Route({
-        controller,
-        type: 'member',
-        path: 'posts/:id',
-        action: 'show',
-        method: 'GET',
-      });
-      dataRoute = new Route({
-        controller,
-        type: 'member',
-        path: 'posts/:id',
-        action: 'create',
-        method: 'PATCH',
-      });
-    });
-
     describe('#parseParams()', () => {
+      let staticRoute: Route;
+      let dynamicRoute: Route;
+      let dataRoute: Route;
+
+      before(async () => {
+        const { controllers } = await getTestApp();
+        // $FlowIgnore
+        const controller: Controller = controllers.get('posts');
+
+        staticRoute = new Route({
+          controller,
+          type: 'collection',
+          path: 'posts',
+          action: 'index',
+          method: 'GET',
+        });
+        dynamicRoute = new Route({
+          controller,
+          type: 'member',
+          path: 'posts/:id',
+          action: 'show',
+          method: 'GET',
+        });
+        dataRoute = new Route({
+          controller,
+          type: 'member',
+          path: 'posts/:id',
+          action: 'create',
+          method: 'PATCH',
+        });
+      });
+
       it('is empty for static paths', () => {
         expect(staticRoute.parseParams(['1'])).to.be.empty;
       });
@@ -54,6 +58,217 @@ describe('module "router/route"', () => {
 
       it('does not contain params for unmatched dynamic segments', () => {
         expect(dynamicRoute.parseParams(['1', '2'])).to.deep.equal({ id: 1 });
+      });
+    });
+
+    describe('#execHandlers()', () => {
+      let subject: Route;
+      let createRequest;
+
+      describe('- with action only', () => {
+        before(async () => {
+          class TestController extends Controller {
+            // $FlowIgnore
+            index = async () => ({
+              meta: {
+                success: true
+              }
+            });
+          }
+
+          subject = new Route({
+            type: 'collection',
+            path: 'tests',
+            action: 'index',
+            method: 'GET',
+            controller: new TestController({
+              namespace: ''
+            })
+          });
+
+          createRequest = createRequestBuilder({
+            path: '/tests',
+            route: subject,
+            params: {}
+          });
+        });
+
+        it('resolves with the correct data', async () => {
+          const result = await subject.execHandlers(
+            createRequest(),
+            createResponse()
+          );
+
+          expect(result).to.deep.equal({
+            meta: {
+              success: true
+            }
+          });
+        });
+      });
+
+      describe('- with `beforeAction`', () => {
+        let beforeSpy;
+
+        before(async () => {
+          const beforeHooks = {
+            call: async () => undefined
+          };
+
+          beforeSpy = spy(beforeHooks, 'call');
+
+          class TestController extends Controller {
+            beforeAction = [
+              beforeHooks.call
+            ];
+
+            // $FlowIgnore
+            index = async () => ({
+              meta: {
+                success: true
+              }
+            });
+          }
+
+          subject = new Route({
+            type: 'collection',
+            path: 'tests',
+            action: 'index',
+            method: 'GET',
+            controller: new TestController({
+              namespace: ''
+            })
+          });
+
+          createRequest = createRequestBuilder({
+            path: '/tests',
+            route: subject,
+            params: {}
+          });
+        });
+
+        it('resolves with the correct data', async () => {
+          const result = await subject.execHandlers(
+            createRequest(),
+            createResponse()
+          );
+
+          expect(beforeSpy.calledOnce).to.be.true;
+          expect(result).to.deep.equal({
+            meta: {
+              success: true
+            }
+          });
+        });
+      });
+
+      describe('- with `afterAction`', () => {
+        before(async () => {
+          class TestController extends Controller {
+            // $FlowIgnore
+            index = async () => ({
+              meta: {
+                success: true,
+                afterSuccess: true
+              }
+            });
+          }
+
+          subject = new Route({
+            type: 'collection',
+            path: 'tests',
+            action: 'index',
+            method: 'GET',
+            controller: new TestController({
+              namespace: ''
+            })
+          });
+
+          createRequest = createRequestBuilder({
+            path: '/tests',
+            route: subject,
+            params: {}
+          });
+        });
+
+        it('resolves with the correct data', async () => {
+          const result = await subject.execHandlers(
+            createRequest(),
+            createResponse()
+          );
+
+          expect(result).to.deep.equal({
+            meta: {
+              success: true,
+              afterSuccess: true
+            }
+          });
+        });
+      });
+
+      describe('- with `beforeAction` and `afterAction`', () => {
+        let beforeSpy;
+
+        before(async () => {
+          const beforeHooks = {
+            call: async () => undefined
+          };
+
+          beforeSpy = spy(beforeHooks, 'call');
+
+          class TestController extends Controller {
+            beforeAction = [
+              beforeHooks.call
+            ];
+
+            afterAction = [
+              async (req, res, { meta }) => ({
+                meta: {
+                  ...meta,
+                  afterSuccess: true
+                }
+              })
+            ];
+
+            // $FlowIgnore
+            index = async () => ({
+              meta: {
+                success: true
+              }
+            });
+          }
+
+          subject = new Route({
+            type: 'collection',
+            path: 'tests',
+            action: 'index',
+            method: 'GET',
+            controller: new TestController({
+              namespace: ''
+            })
+          });
+
+          createRequest = createRequestBuilder({
+            path: '/tests',
+            route: subject,
+            params: {}
+          });
+        });
+
+        it('resolves with the correct data', async () => {
+          const result = await subject.execHandlers(
+            createRequest(),
+            createResponse()
+          );
+
+          expect(beforeSpy.calledOnce).to.be.true;
+          expect(result).to.deep.equal({
+            meta: {
+              success: true,
+              afterSuccess: true
+            }
+          });
+        });
       });
     });
   });

--- a/src/packages/router/route/test/route.test.js
+++ b/src/packages/router/route/test/route.test.js
@@ -15,6 +15,65 @@ import Route from '../index';
 
 describe('module "router/route"', () => {
   describe('class Route', () => {
+    describe('#constructor()', () => {
+      let controller: Controller;
+
+      before(async () => {
+        const { controllers } = await getTestApp();
+
+        // $FlowIgnore
+        controller = controllers.get('posts');
+      });
+
+      it('creates an instance of route', () => {
+        const result = new Route({
+          controller,
+          type: 'collection',
+          path: 'posts',
+          action: 'index',
+          method: 'GET'
+        });
+
+        expect(result).to.be.an.instanceOf(Route);
+      });
+
+      it('throws when a handler is not found', () => {
+        expect(() => {
+          new Route({
+            controller,
+            type: 'collection',
+            path: 'posts',
+            action: 'invalidHandler',
+            method: 'GET'
+          });
+        }).to.throw(TypeError);
+      });
+
+      it('throws when an an action is not provided', () => {
+        expect(() => {
+          // $FlowIgnore
+          new Route({
+            controller,
+            type: 'collection',
+            path: 'posts',
+            method: 'GET'
+          });
+        }).to.throw(TypeError);
+      });
+
+      it('throws when an an controller is not provided', () => {
+        expect(() => {
+          // $FlowIgnore
+          new Route({
+            type: 'collection',
+            path: 'posts',
+            action: 'index',
+            method: 'GET'
+          });
+        }).to.throw(TypeError);
+      });
+    });
+
     describe('#parseParams()', () => {
       let staticRoute: Route;
       let dynamicRoute: Route;
@@ -112,7 +171,9 @@ describe('module "router/route"', () => {
           class TestController extends Controller {
             beforeAction = [
               async () => ({
-                beforeSuccess: true
+                meta: {
+                  beforeSuccess: true
+                }
               })
             ];
 

--- a/src/packages/router/route/test/route.test.js
+++ b/src/packages/router/route/test/route.test.js
@@ -108,18 +108,12 @@ describe('module "router/route"', () => {
       });
 
       describe('- with `beforeAction`', () => {
-        let beforeSpy;
-
         before(async () => {
-          const beforeHooks = {
-            call: async () => undefined
-          };
-
-          beforeSpy = spy(beforeHooks, 'call');
-
           class TestController extends Controller {
             beforeAction = [
-              beforeHooks.call
+              async () => ({
+                beforeSuccess: true
+              })
             ];
 
             // $FlowIgnore
@@ -153,10 +147,9 @@ describe('module "router/route"', () => {
             createResponse()
           );
 
-          expect(beforeSpy.calledOnce).to.be.true;
           expect(result).to.deep.equal({
             meta: {
-              success: true
+              beforeSuccess: true
             }
           });
         });

--- a/src/utils/sleep.js
+++ b/src/utils/sleep.js
@@ -1,0 +1,8 @@
+// @flow
+
+/**
+ * @private
+ */
+export default function sleep(amount: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, amount));
+}

--- a/src/utils/test/sleep.test.js
+++ b/src/utils/test/sleep.test.js
@@ -1,0 +1,25 @@
+// @flow
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+
+import sleep from '../sleep';
+
+describe('util sleep()', function () {
+  const amount = 500;
+  let time;
+
+  this.slow(1000);
+
+  beforeEach(() => {
+    time = Date.now();
+  });
+
+  it('resolves with undefined', async () => {
+    expect(await sleep(amount)).to.be.undefined;
+  });
+
+  it('sleeps for the correct amount of time', async () => {
+    await sleep(amount);
+    expect(Date.now() - time).to.be.at.least(amount);
+  });
+});

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -1,0 +1,69 @@
+// @flow
+import K from '../../src/utils/k';
+import type { Request, Response } from '../../src/packages/server';
+
+const RESPONSE_HEADERS = new WeakMap();
+
+function headersFor(res: Response): Map<string, string> {
+  let headers = RESPONSE_HEADERS.get(res);
+
+  if (!headers) {
+    headers = new Map();
+    RESPONSE_HEADERS.set(res, headers);
+  }
+
+  return headers;
+}
+
+// $FlowIgnore
+export const createResponse = (): Response => ({
+  on: K,
+  end: K,
+  stats: [],
+  statusCode: 200,
+  statusMessage: 'OK',
+
+  getHeader(key: string) {
+    return headersFor(this).get(key);
+  },
+
+  setHeader(key: string, value: string) {
+    headersFor(this).set(key, value);
+  },
+
+  removeHeader(key: string) {
+    headersFor(this).delete(key);
+  }
+});
+
+//$FlowIgnore
+export const createRequestBuilder = ({
+  path,
+  route,
+  params
+  //$FlowIgnore
+}) => (): Request => ({
+  route,
+  params,
+  method: 'GET',
+  url: {
+    protocol: null,
+    slashes: null,
+    auth: null,
+    host: null,
+    port: null,
+    hostname: null,
+    hash: null,
+    search: '',
+    query: {},
+    pathname: path,
+    path: path,
+    href: path
+  },
+  headers: new Map([
+    ['host', 'localhost:4000']
+  ]),
+  connection: {
+    encrypted: false
+  }
+});


### PR DESCRIPTION
Adds `afterAction` middleware hook to the public `Controller` API.

--

### Usage

After action provides a way to easily alter the response data for a particular request.

In the example below we will add copyright info to a meta object of the response data.

```javascript
import { Controller } from 'lux-framework';

async function authenticate(req, res) {
  if (!req.currentUser) {
    return false;
  }
}

async function addCopyright(req, res, data) {
  if (data && typeof data === 'object' && !Array.isArray(data)) {
    return {
      ...data,
      meta: {
        ...(data.meta || {}),
        copyright: 'Copyright (c) 2016 Postlight'
      }
    };  
  }

  return data;
}

class ApplicationController extends Controller {
  beforeAction = [
    authenticate
  ];

  afterAction = [
    addCopyright
  ];
}

export default ApplicationController;
```

Like the `beforeAction` hook `afterAction` also inherits functions from the parent of the `Controller`. Unlike `beforeAction` hooks, functions added to the `afterAction` hook will be executed from the bottom up rather than the top down. That means that child functions are executed before parent functions.

Consider the following example...

```javascript
import { Controller } from 'lux-framework';

async function setFilter(req, res) {
  if (req.action === 'index') {
    req.params.filter.isPublic = true;
  }
}

async function addTotal(req, res, data) {
  if (req.action === 'index') {
    return {
      ...data,
      meta: {
        ...(data.meta || {}),
        total: await this.index(req, res).count()
      }
    };
  }

  return data;
}

class PostsController extends Controller {
  beforeAction = [
    setFilter
  ];

  afterAction = [
    addTotal
  ];
}

export default PostsController;
```

If we make a request to the index action of our `PostsController` (`/posts` ), the functions declared in our controllers above will be executed in the following order:

1. `authenticate` - from the `beforeAction` hook on the `ApplicationController`
2. `setFilter` - from the `beforeAction` hook on the `PostsController`
3. `PostsController#index` - the index action on the `PostsController`
4. `addTotal` - from the `afterAction` hook on the `PostsController`
5. `addCopyright` - from the `afterAction` hook on the `ApplicationController`
