### PR TITLE
feat: expose controller and action in public request api

### DIFF
--- a/src/packages/server/request/index.js
+++ b/src/packages/server/request/index.js
@@ -23,7 +23,15 @@ export function createRequest(req: any, {
     method: headers.get('x-http-method-override') || req.method
   });
 
-  Reflect.set(req, 'route', router.match(req));
+  const route = router.match(req);
+
+  if (route) {
+    Object.assign(req, {
+      route,
+      action: route.action,
+      controller: route.controller
+    });
+  }
 
   return req;
 }

--- a/src/packages/server/request/interfaces.js
+++ b/src/packages/server/request/interfaces.js
@@ -1,6 +1,7 @@
 // @flow
 import type Logger from '../../logger';
 import type Router, { Route } from '../../router';
+import type Controller from '../../controller';
 
 export type Request$opts = {
   logger: Logger;
@@ -61,6 +62,8 @@ declare export class Request extends stream$Readable {
   params: Request$params;
   defaultParams: Request$params;
   route: Route;
+  action: string;
+  controller: Controller;
   url: Request$url;
 
   connection: {


### PR DESCRIPTION
Adds the ability to access `req.action` (e.g `'index', `'show'`, etc.`) and `req.controller` (e.g `PostsController`).