### PR TITLE
refactor: ensure tableName is statically evaluated

### DIFF
--- a/src/packages/database/model/index.js
+++ b/src/packages/database/model/index.js
@@ -7,6 +7,7 @@ import { sql } from '../../logger';
 import { saveRelationships } from '../relationship';
 import pick from '../../../utils/pick';
 import omit from '../../../utils/omit';
+import chain from '../../../utils/chain';
 import setType from '../../../utils/set-type';
 import underscore from '../../../utils/underscore';
 import type Logger from '../../logger'; // eslint-disable-line max-len, no-duplicate-imports
@@ -19,6 +20,15 @@ import getColumns from './utils/get-columns';
 import validate from './utils/validate';
 
 class Model {
+  /**
+   * The name of the corresponding database table for a `Model` instance's
+   * constructor.
+   *
+   * @property tableName
+   * @memberof Model
+   */
+  tableName: string;
+
   /**
    * The canonical name of a `Model`'s constructor.
    *
@@ -85,20 +95,20 @@ class Model {
   static primaryKey: string = 'id';
 
   /**
-   * The canonical name of a `Model`.
-   *
-   * @property modelName
-   * @memberof Model
-   */
-  static modelName: string;
-
-  /**
    * The name of the corresponding database table for a `Model`.
    *
    * @property tableName
    * @memberof Model
    */
   static tableName: string;
+
+  /**
+   * The canonical name of a `Model`.
+   *
+   * @property modelName
+   * @memberof Model
+   */
+  static modelName: string;
 
   /**
    * The name of the API resource a `Model` represents.
@@ -438,10 +448,22 @@ class Model {
     }
 
     if (!this.tableName) {
+      const tableName = chain(this.name)
+        .pipe(underscore)
+        .pipe(pluralize)
+        .value();
+
       Reflect.defineProperty(this, 'tableName', {
-        value: pluralize(underscore(this.name)),
+        value: tableName,
         writable: false,
         enumerable: true,
+        configurable: false
+      });
+
+      Reflect.defineProperty(this.prototype, 'tableName', {
+        value: tableName,
+        writable: false,
+        enumerable: false,
         configurable: false
       });
     }

--- a/src/packages/database/model/index.js
+++ b/src/packages/database/model/index.js
@@ -93,6 +93,14 @@ class Model {
   static modelName: string;
 
   /**
+   * The name of the corresponding database table for a `Model`.
+   *
+   * @property tableName
+   * @memberof Model
+   */
+  static tableName: string;
+
+  /**
    * The name of the API resource a `Model` represents.
    *
    * @property resourceName
@@ -299,21 +307,6 @@ class Model {
     }
   }
 
-  static get tableName(): string {
-    return pluralize(underscore(this.name));
-  }
-
-  static set tableName(value: string): void {
-    if (value && value.length) {
-      Reflect.defineProperty(this, 'tableName', {
-        value,
-        writable: false,
-        enumerable: false,
-        configurable: false
-      });
-    }
-  }
-
   async save(deep?: boolean): Promise<this> {
     const {
       constructor: {
@@ -442,6 +435,15 @@ class Model {
   static initialize(store, table): Promise<Class<this>> {
     if (this.initialized) {
       return Promise.resolve(this);
+    }
+
+    if (!this.tableName) {
+      Reflect.defineProperty(this, 'tableName', {
+        value: pluralize(underscore(this.name)),
+        writable: false,
+        enumerable: true,
+        configurable: false
+      });
     }
 
     return initializeClass({

--- a/src/packages/database/test/model.test.js
+++ b/src/packages/database/test/model.test.js
@@ -258,24 +258,43 @@ describe('module "database/model"', () => {
         expect(Subject.validates.title).to.be.a('function');
       });
 
-      it('adds an `modelName` property to the `Model`', () => {
-        expect(Subject.modelName).to.equal('subject');
+      it('adds a `modelName` property to the `Model`', () => {
+        expect(Subject).to.have.property('modelName', 'subject');
       });
 
-      it('adds an `modelName` property to the `prototype`', () => {
-        expect(Subject.prototype.modelName).to.equal('subject');
+      it('adds a `modelName` property to the `prototype`', () => {
+        expect(Subject).to.have.deep.property('prototype.modelName', 'subject');
       });
 
-      it('adds an `resourceName` property to the `Model`', () => {
-        expect(Subject.resourceName).to.equal('subjects');
+      it('adds a `resourceName` property to the `Model`', () => {
+        expect(Subject).to.have.property('resourceName', 'subjects');
       });
 
-      it('adds an `resourceName` property to the `prototype`', () => {
-        expect(Subject.prototype.resourceName).to.equal('subjects');
+      it('adds a `resourceName` property to the `prototype`', () => {
+        expect(Subject)
+          .to.have.deep.property('prototype.resourceName', 'subjects');
       });
 
       it('adds an `initialized` property to the `Model`', () => {
         expect(Subject.initialized).to.be.true;
+      });
+
+      describe('- without `tableName`', () => {
+        class Post extends Model {}
+
+        before(async () => {
+          await Post.initialize(store, () => {
+            return store.connection(Post.tableName);
+          });
+        });
+
+        it('adds a `tableName` property to the `prototype`', () => {
+          expect(Post).to.have.property('tableName', 'posts');
+        });
+
+        it('adds a `tableName` property to the `prototype`', () => {
+          expect(Post).to.have.deep.property('prototype.tableName', 'posts');
+        });
       });
     });
 


### PR DESCRIPTION
Seeing a pretty significant perf increase from this change!

*Before:*

```bash
$ wrk -c 64 -d 30 http://localhost:4000/posts/1

Running 30s test @ http://localhost:4000/posts/1
  2 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    50.53ms   23.54ms 234.52ms   72.10%
    Req/Sec   646.46     82.86   808.00     78.83%
  38676 requests in 30.06s, 44.81MB read
Requests/sec:   1286.49
Transfer/sec:      1.49MB
```

*After:*

```bash
$ wrk -c 64 -d 30 http://localhost:4000/posts/1

Running 30s test @ http://localhost:4000/posts/1
  2 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    43.10ms   19.98ms 191.58ms   72.16%
    Req/Sec   758.54     83.87     1.00k    69.50%
  45367 requests in 30.05s, 52.57MB read
Requests/sec:   1509.88
Transfer/sec:      1.75MB
```