### PR TITLE
fix: readdir error is causing cli commands to fail

### DIFF
--- a/src/packages/compiler/index.js
+++ b/src/packages/compiler/index.js
@@ -31,14 +31,8 @@ export async function compile(dir: string, env: string, {
   const entry = path.join(dir, 'dist', 'index.js');
 
   const nodeModules = path.join(dir, 'node_modules');
-  const luxNodeModules = path.join(__dirname, '..', 'node_modules');
-  const sourceMapSupport = path.join(luxNodeModules, 'source-map-support');
-
-  const external = await Promise.all([
-    readdir(nodeModules),
-    readdir(luxNodeModules)
-  ]).then(([a, b]: [Array<string>, Array<string>]) => (
-    a.concat(b).filter(name => name !== 'lux-framework')
+  const external = await readdir(nodeModules).then(files => (
+    files.filter(name => name !== 'lux-framework')
   ));
 
   const assets = await Promise.all([
@@ -76,7 +70,6 @@ export async function compile(dir: string, env: string, {
     createManifest(dir, assets, {
       useStrict
     }),
-
     createBootScript(dir, {
       useStrict
     })
@@ -86,7 +79,6 @@ export async function compile(dir: string, env: string, {
     entry,
     onwarn,
     external,
-
     plugins: [
       alias({
         resolve: ['.js'],
@@ -120,9 +112,7 @@ export async function compile(dir: string, env: string, {
   await rmrf(entry);
 
   banner = template`
-    const srcmap = require('${
-      sourceMapSupport.replace(BACKSLASH, '/')
-    }').install({
+    const srcmap = require('source-map-support').install({
       environment: 'node'
     });
   `;

--- a/src/packages/compiler/index.js
+++ b/src/packages/compiler/index.js
@@ -8,7 +8,6 @@ import eslint from 'rollup-plugin-eslint';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import { rollup } from 'rollup';
 
-import { BACKSLASH } from '../../constants';
 import { rmrf, readdir, readdirRec, isJSFile } from '../fs';
 import template from '../template';
 

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -17,6 +17,7 @@
     "mssql": "3.3.0",
     "mysql2": "1.1.1",
     "pg": "6.1.0",
+    "source-map-support": "0.4.5",
     "sqlite3": "3.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes the following error.

```
Building your application...{ Error: ENOENT: no such file or directory, scandir '/Users/zacharygolba/Desktop/blog/node_modules/lux-framework/node_modules'
    at Error (native)
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: '/Users/zacharygolba/Desktop/blog/node_modules/lux-framework/node_modules' }
```