### PR TITLE
fix: controllers are not properly resolving for resources with custom…

### DIFF
--- a/src/packages/compiler/utils/create-manifest.js
+++ b/src/packages/compiler/utils/create-manifest.js
@@ -44,13 +44,6 @@ function createWriter(file: string) {
         const path = joinPath('app', pluralize(type), item);
         const name = chain(item)
           .pipe(formatName)
-          .pipe(str => {
-            if (str.endsWith('Application')) {
-              return str;
-            }
-
-            return pluralize(str);
-          })
           .pipe(str => str + capitalize(type))
           .value();
 

--- a/src/packages/router/definitions/context/index.js
+++ b/src/packages/router/definitions/context/index.js
@@ -81,7 +81,15 @@ export function contextFor(build: Router$DefinitionBuilder<*>) {
               path = namespace.path + opts.path;
             }
 
-            const controllerKey = path.substr(1);
+            const controllerKey = path
+              .split('/')
+              .filter(Boolean)
+              .reduce((arr, str, index, parts) => [
+                ...arr,
+                index === parts.length - 1 ? opts.name : str
+              ], [])
+              .join('/');
+
             const controller = controllers.get(controllerKey);
 
             if (!controller) {


### PR DESCRIPTION
This PR fixes a bug where adding a custom path to a resources causes the controller look up to fail.

```javascript
export default function routes() {
  this.resource('articles', { path: '/posts' });
  // ^ The line above would cause the controller lookup to resolve to a controller
  //   with the name PostsController instead of ArticlesController.
}
```