### PR TITLE
fix: some strings in request body cast to another type

### DIFF
--- a/src/packages/server/request/parser/constants.js
+++ b/src/packages/server/request/parser/constants.js
@@ -1,6 +1,7 @@
 // @flow
 export const INT = /^\d+$/;
-export const BOOL = /^(true|false)$/;
+export const NULL = /^null$/;
+export const BOOL = /^(?:true|false)$/;
 export const DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|\+\d{4})$/;
 export const TRUE = /^true$/;
-export const BRACKETS = /(\[])/g;
+export const BRACKETS = /(?:\[])/g;

--- a/src/packages/server/request/parser/utils/format.js
+++ b/src/packages/server/request/parser/utils/format.js
@@ -1,7 +1,7 @@
 // @flow
 import { camelize } from 'inflection';
 
-import { INT, BOOL, DATE, TRUE, BRACKETS } from '../constants';
+import { INT, NULL, BOOL, DATE, TRUE, BRACKETS } from '../constants';
 import isNull from '../../../../../utils/is-null';
 import entries from '../../../../../utils/entries';
 import underscore from '../../../../../utils/underscore';
@@ -23,13 +23,19 @@ function makeArray(source: string | Array<string>): Array<string> {
  * @private
  */
 function formatString(source: string, method: Request$method): mixed {
-  if (method === 'GET' && source.indexOf(',') >= 0) {
-    return source.split(',').map(str => camelize(underscore(str), true));
-  } else if (INT.test(source)) {
-    return Number.parseInt(source, 10);
-  } else if (BOOL.test(source)) {
-    return TRUE.test(source);
-  } else if (DATE.test(source)) {
+  if (method === 'GET') {
+    if (source.indexOf(',') >= 0) {
+      return source.split(',').map(str => camelize(underscore(str), true));
+    } else if (INT.test(source)) {
+      return Number.parseInt(source, 10);
+    } else if (BOOL.test(source)) {
+      return TRUE.test(source);
+    } else if (NULL.test(source)) {
+      return null;
+    }
+  }
+
+  if (DATE.test(source)) {
     return new Date(source);
   }
 

--- a/src/packages/server/request/test/request.test.js
+++ b/src/packages/server/request/test/request.test.js
@@ -89,10 +89,15 @@ describe('module "server/request"', () => {
 
   describe('#parseRequest()', () => {
     it('can parse params from a GET request', () => {
+      const now = new Date().toISOString();
       const url = '/posts?'
         + 'fields[posts]=body,title'
         + '&fields[users]=name'
-        + '&include=user';
+        + '&include=user'
+        + '&filter[is-public]=true'
+        + '&filter[title]=123'
+        + '&filter[body]=null'
+        + `&filter[created-at]=${now}`;
 
       return test(url, {
         method: 'GET'
@@ -101,12 +106,27 @@ describe('module "server/request"', () => {
 
         expect(params).to.deep.equal({
           fields: ['body', 'title'],
-          include: ['user']
+          include: ['user'],
+          filter: {
+            body: null,
+            title: 123,
+            isPublic: true
+          }
         });
+
+        expect(params)
+          .to.have.deep.property('filter.createdAt')
+          .and.be.an.instanceOf(Date);
+
+        expect(
+          params.filter.createdAt.valueOf()
+        ).to.equal(new Date(now).valueOf());
       });
     });
 
     it('can parse params from a POST request', () => {
+      const now = new Date().toISOString();
+
       return test('/posts?include=user', {
         method: 'POST',
         body: {
@@ -114,7 +134,11 @@ describe('module "server/request"', () => {
             type: 'posts',
             attributes: {
               title: 'New Post 1',
-              'is-public': true
+              'is-public': true,
+              intString: '123',
+              nullString: 'null',
+              boolString: 'true',
+              dateString: now
             },
             relationships: {
               user: {
@@ -153,7 +177,11 @@ describe('module "server/request"', () => {
             type: 'posts',
             attributes: {
               title: 'New Post 1',
-              isPublic: true
+              isPublic: true,
+              intString: '123',
+              nullString: 'null',
+              boolString: 'true',
+              dateString: now
             },
             relationships: {
               user: {
@@ -186,6 +214,8 @@ describe('module "server/request"', () => {
     });
 
     it('can parse params from a PATCH request', () => {
+      const now = new Date().toISOString();
+
       return test('/posts/1?include=user', {
         method: 'PATCH',
         data: {
@@ -193,7 +223,11 @@ describe('module "server/request"', () => {
           type: 'posts',
           attributes: {
             title: 'New Post 1',
-            'is-public': true
+            'is-public': true,
+            intString: '123',
+            nullString: 'null',
+            boolString: 'true',
+            dateString: now
           },
           relationships: {
             user: {
@@ -231,7 +265,11 @@ describe('module "server/request"', () => {
             type: 'posts',
             attributes: {
               title: 'New Post 1',
-              isPublic: true
+              isPublic: true,
+              intString: '123',
+              nullString: 'null',
+              boolString: 'true',
+              dateString: now
             },
             relationships: {
               user: {


### PR DESCRIPTION
When query params come in from a `GET` request, they are always a string. Often times you want them to reflect the value that they actually represent. A few of the type conversions that Lux applies to make handling query params easier were wrongfully applied to incoming JSON payloads from a `POST` or `PATCH` request. JSON can contain some of these data types that are converted, therefore we should not try to convert the string `'123'` to the number `123` as it is probably intended to be a string.

This PR ensues that these type conversions take the request method into account and do not unnecessarily/wrongfully convert certain types in incoming request bodies. Test have been added for this behavior to prevent future regressions.

Closes #499 