### PR TITLE
chore: use codecov bash uploader

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "remark . && eslint .",
     "start": "lux serve",
     "test": "npm run build && nyc -i ./lib/babel-hook.js --instrument false --source-map false mocha -r ./lib/babel-hook.js test/index.js src/**/*.test.js",
-    "test:codecov": "nyc report --reporter=lcov > coverage.lcov && codecov -t $LUX_CODECOV_TOKEN"
+    "test:codecov": "nyc report --reporter=lcov > coverage.lcov && bash <(curl -s https://codecov.io/bash)"
   },
   "author": "Zachary Golba",
   "license": "MIT",
@@ -59,7 +59,6 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.18.0",
     "babel-preset-lux": "1.3.0",
     "chai": "3.5.0",
-    "codecov": "1.0.1",
     "eslint-config-airbnb-base": "10.0.1",
     "eslint-plugin-flowtype": "2.25.0",
     "eslint-plugin-import": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "remark . && eslint .",
     "start": "lux serve",
     "test": "npm run build && nyc -i ./lib/babel-hook.js --instrument false --source-map false mocha -r ./lib/babel-hook.js test/index.js src/**/*.test.js",
-    "test:codecov": "nyc report --reporter=lcov > coverage.lcov && bash <(curl -s https://codecov.io/bash)"
+    "test:codecov": "nyc report --reporter=lcov > coverage.lcov && curl -s https://codecov.io/bash | bash"
   },
   "author": "Zachary Golba",
   "license": "MIT",


### PR DESCRIPTION
Switches to use the codecov [bash uploader](http://docs.codecov.io/docs/about-the-codecov-bash-uploader) rather than the npm package.