### PR TITLE
fix: empty 1:1 relationships are not returned in correct format

### DIFF
--- a/src/packages/serializer/index.js
+++ b/src/packages/serializer/index.js
@@ -633,7 +633,9 @@ class Serializer<T: Model> {
               });
             }
 
-            return null;
+            return {
+              data: null
+            };
           })()
         }), {})
       );

--- a/src/packages/serializer/test/serializer.test.js
+++ b/src/packages/serializer/test/serializer.test.js
@@ -287,7 +287,9 @@ describe('module "serializer"', () => {
             }
           });
         } else {
-          expect(relationships.image).to.be.null;
+          expect(relationships.image).to.deep.equal({
+            data: null
+          });
         }
 
         expect(relationships)


### PR DESCRIPTION
Closes #519 

cc @nickschot 