### PR TITLE
fix: ids in json payloads should be cast to number

### DIFF
--- a/src/packages/server/request/parser/utils/format.js
+++ b/src/packages/server/request/parser/utils/format.js
@@ -111,7 +111,7 @@ export default function format(params: Object, method: Request$method): Object {
       case 'string':
         return {
           ...obj,
-          [key]: formatString(value, method)
+          [key]: formatString(value, key === 'id' ? 'GET' : method)
         };
 
       default:


### PR DESCRIPTION
#506 made it impossible to use strings as an id in `POST` and `PATCH` requests. This PR makes it so the type cast still applies to id fields.