### PR TITLE
[WIP] Fix potential issue in names such as `ControllerAController`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 # misc
 *.sqlite
 *.DS_Store
+.idea/
 
 # logs
 log/

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ node_modules/
 .nyc_output/
 coverage/
 examples/
+.idea/
 
 # logs
 log/

--- a/src/packages/loader/utils/bundle-for.js
+++ b/src/packages/loader/utils/bundle-for.js
@@ -19,7 +19,11 @@ function normalize(manifest: Object) {
   return entries(manifest).reduce((obj, [key, value]) => {
     if (SUFFIX_PATTERN.test(key)) {
       const suffix = key.replace(SUFFIX_PATTERN, '$1');
-      const stripSuffix = source => source.replace(suffix, '');
+      const suffixRegexp = new RegExp(
+        `${suffix.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}$`,
+        'g'
+      );
+      const stripSuffix = source => source.replace(suffixRegexp, '');
 
       switch (suffix) {
         case 'Controller':


### PR DESCRIPTION
I know it's not very common, but while browsing the code trying to fix another bug, I realized that if one had some items named as `SerializerASerializer` or `MyControllerOfTheWorldController`, then the type won't be stripped from the end only, but also from within the middle of the names, ie `A` and `MyOfTheWorld`.

This is just a simple fix to ensure stripping the type only from the end of the name. 