### PR TITLE
fix: array qp being parsed to a string instead of an array when it contains a single value

### DIFF
--- a/src/packages/server/request/parser/utils/format.js
+++ b/src/packages/server/request/parser/utils/format.js
@@ -96,8 +96,12 @@ export function formatInclude(include: string | Array<string>): Array<string> {
  */
 export default function format(params: Object, method: Request$method): Object {
   const result = entries(params).reduce((obj, param) => {
-    const [, value] = param;
+    let [, value] = param;
     let [key] = param;
+
+    if (key.endsWith('[]') && !Array.isArray(value)) {
+      value = [value];
+    }
 
     key = key.replace(BRACKETS, '');
 


### PR DESCRIPTION
Proposed fix for #637 