### PR TITLE
fix: make sure result is an instanceof Query (and not just a promise) (related to #603)

### DIFF
--- a/src/packages/router/route/action/enhancers/resource.js
+++ b/src/packages/router/route/action/enhancers/resource.js
@@ -16,7 +16,7 @@ export default function resource(action: Action<any>): Action<any> {
     let data;
     let total;
 
-    if (actionName === 'index') {
+    if (actionName === 'index' && result instanceof Query) {
       [data, total] = await Promise.all([
         result,
         Query.from(result).count()


### PR DESCRIPTION
When returning a promise which resolves into a Query, the index route would throw an error.

See #603 for more info.