### PR TITLE
fix: properly set environment before running db:* commands

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -168,9 +168,14 @@ cli
 cli
   .command('db:create')
   .description('Create your database schema')
+  .option('-e, --environment [env]', '(Default: development)')
   .option('-w, --use-weak', 'Use weak mode')
-  .action(({ useWeak }) => {
-    exec('build', !useWeak)
+  .action(({ environment, useWeak }) => {
+    const useStrict = !useWeak;
+
+    setEnvVar('NODE_ENV', environment, 'development');
+
+    exec('build', useStrict)
       .then(() => exec('dbcreate'))
       .then(exit)
       .catch(rescue);
@@ -179,9 +184,14 @@ cli
 cli
   .command('db:drop')
   .description('Drop your database schema')
+  .option('-e, --environment [env]', '(Default: development)')
   .option('-w, --use-weak', 'Use weak mode')
-  .action(({ useWeak }) => {
-    exec('build', !useWeak)
+  .action(({ environment, useWeak }) => {
+    const useStrict = !useWeak;
+
+    setEnvVar('NODE_ENV', environment, 'development');
+
+    exec('build', useStrict)
       .then(() => exec('dbdrop'))
       .then(exit)
       .catch(rescue);
@@ -190,9 +200,14 @@ cli
 cli
   .command('db:reset')
   .description('Drop your database schema and create a new schema')
+  .option('-e, --environment [env]', '(Default: development)')
   .option('-w, --use-weak', 'Use weak mode')
-  .action(({ useWeak }) => {
-    exec('build', !useWeak)
+  .action(({ environment, useWeak }) => {
+    const useStrict = !useWeak;
+
+    setEnvVar('NODE_ENV', environment, 'development');
+
+    exec('build', useStrict)
       .then(() => exec('dbdrop'))
       .then(() => exec('dbcreate'))
       .then(exit)
@@ -202,9 +217,14 @@ cli
 cli
   .command('db:migrate')
   .description('Run database migrations')
+  .option('-e, --environment [env]', '(Default: development)')
   .option('-w, --use-weak', 'Use weak mode')
-  .action(({ useWeak }) => {
-    exec('build', !useWeak)
+  .action(({ environment, useWeak }) => {
+    const useStrict = !useWeak;
+
+    setEnvVar('NODE_ENV', environment, 'development');
+
+    exec('build', useStrict)
       .then(() => exec('dbmigrate'))
       .then(exit)
       .catch(rescue);
@@ -213,9 +233,14 @@ cli
 cli
   .command('db:rollback')
   .description('Rollback the last database migration')
+  .option('-e, --environment [env]', '(Default: development)')
   .option('-w, --use-weak', 'Use weak mode')
-  .action(({ useWeak }) => {
-    exec('build', !useWeak)
+  .action(({ environment, useWeak }) => {
+    const useStrict = !useWeak;
+
+    setEnvVar('NODE_ENV', environment, 'development');
+
+    exec('build', useStrict)
       .then(() => exec('dbrollback'))
       .then(exit)
       .catch(rescue);
@@ -224,9 +249,14 @@ cli
 cli
   .command('db:seed')
   .description('Add fixtures to your db from the seed function')
+  .option('-e, --environment [env]', '(Default: development)')
   .option('-w, --use-weak', 'Use weak mode')
-  .action(({ useWeak }) => {
-    exec('build', !useWeak)
+  .action(({ environment, useWeak }) => {
+    const useStrict = !useWeak;
+
+    setEnvVar('NODE_ENV', environment, 'development');
+
+    exec('build', useStrict)
       .then(() => exec('dbseed'))
       .then(exit)
       .catch(rescue);

--- a/src/packages/cli/commands/dbcreate.js
+++ b/src/packages/cli/commands/dbcreate.js
@@ -1,7 +1,9 @@
+// @flow
 import { EOL } from 'os';
 
 import { CWD, NODE_ENV, DATABASE_URL } from '../../../constants';
 import { CONNECTION_STRING_MESSAGE } from '../constants';
+import DatabaseConfigMissingError from '../errors/database-config-missing';
 import { connect } from '../../database';
 import { writeFile } from '../../fs';
 import { createLoader } from '../../loader';
@@ -9,36 +11,29 @@ import { createLoader } from '../../loader';
 /**
  * @private
  */
-export async function dbcreate() {
+export function dbcreate() {
   const load = createLoader(CWD);
-  let cfg = load('config');
+  const config = Reflect.get(load('config').database, NODE_ENV);
 
-  cfg = Reflect.get(cfg.database, NODE_ENV);
-
-  const {
-    url,
-    driver,
-    database,
-    ...config
-  } = cfg;
-
-  if (driver === 'sqlite3') {
-    await writeFile(`${CWD}/db/${database}_${NODE_ENV}.sqlite`, '');
-  } else {
-    if (DATABASE_URL || url) {
-      process.stderr.write(CONNECTION_STRING_MESSAGE);
-      process.stderr.write(EOL);
-      return;
-    }
-
-    const { schema } = connect(CWD, { ...config, driver });
-    const query = schema.raw(`CREATE DATABASE ${database}`);
-
-    query.on('query', () => {
-      process.stdout.write(query.toString());
-      process.stdout.write(EOL);
-    });
-
-    await query;
+  if (!config) {
+    throw new DatabaseConfigMissingError(NODE_ENV);
   }
+
+  if (config.driver === 'sqlite3') {
+    return writeFile(`${CWD}/db/${config.database}_${NODE_ENV}.sqlite`, '');
+  }
+
+  if (DATABASE_URL || config.url) {
+    process.stderr.write(CONNECTION_STRING_MESSAGE);
+    process.stderr.write(EOL);
+    return Promise.resolve();
+  }
+
+  const { schema } = connect(CWD, config);
+  const query = `CREATE DATABASE ${config.database}`;
+
+  return schema.raw(query).once('query', () => {
+    process.stdout.write(query);
+    process.stdout.write(EOL);
+  });
 }

--- a/src/packages/cli/errors/database-config-missing.js
+++ b/src/packages/cli/errors/database-config-missing.js
@@ -1,0 +1,8 @@
+// @flow
+class DatabaseConfigMissingError extends ReferenceError {
+  constructor(environment: string) {
+    super(`Could not find database config for environment "${environment}".`);
+  }
+}
+
+export default DatabaseConfigMissingError;


### PR DESCRIPTION
Closes #624.

Also adds `-e, --environment [env]  (Default: development)` to all `db:*` commands.