### PR TITLE
feat: Add ability to specify the records id when calling model.create()

### DIFF
--- a/src/packages/database/model/utils/persistence.js
+++ b/src/packages/database/model/utils/persistence.js
@@ -23,12 +23,19 @@ export function create(record: Model, trx: Object): Array<Object> {
     updatedAt: timestamp
   });
 
+  const { constructor: { primaryKey } } = record;
+  const columns = omit(getColumns(record), primaryKey);
+
+  if (record.dirtyAttributes.has(primaryKey)) {
+    columns[primaryKey] = record.getPrimaryKey();
+  }
+
   return [
     record.constructor
       .table()
       .transacting(trx)
       .returning(record.constructor.primaryKey)
-      .insert(omit(getColumns(record), record.constructor.primaryKey))
+      .insert(columns)
   ];
 }
 

--- a/src/packages/database/test/model.test.js
+++ b/src/packages/database/test/model.test.js
@@ -348,13 +348,13 @@ describe('module "database/model"', () => {
         };
       }
 
-      before(async () => {
+      beforeEach(async () => {
         await Subject.initialize(store, () => {
           return store.connection(Subject.tableName);
         });
       });
 
-      after(async () => {
+      afterEach(async () => {
         await result.destroy();
       });
 
@@ -382,6 +382,16 @@ describe('module "database/model"', () => {
         // $FlowIgnore
         expect(await result.user).to.have.property('id', user.getPrimaryKey());
       });
+
+      it('constructs and persists a `Model` instance with an integer id specified', async () => {
+        const id = 999;
+
+        result = await Subject.create({ id });
+
+        expect(result).to.be.an.instanceof(Subject);
+        expect(result).to.have.property('id', id);
+      });
+
     });
 
     describe('.transacting()', async () => {


### PR DESCRIPTION
@zacharygolba here's the first pass, just pushing to start the discussion on the implementation of this.

refs: #678 