### PR TITLE
feat: source code & test app debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "flow": "flow check",
     "types": "shx rm -rf flow-typed && flow-typed install",
     "lint": "remark . && eslint .",
-    "test": "nyc -i ./lib/babel-hook.js --instrument false --source-map false mocha --opts mocha.opts"
+    "test": "nyc -i ./lib/babel-hook.js --instrument false --source-map false mocha --opts mocha.opts",
+    "debugger": "node test/utils/debugger/dist/debug.js",
+    "build:debugger": "rollup -c test/utils/debugger/rollup.config.js"
   },
   "author": "Zachary Golba",
   "license": "MIT",

--- a/test/utils/debugger/rollup.config.js
+++ b/test/utils/debugger/rollup.config.js
@@ -1,0 +1,38 @@
+import path from 'path';
+
+import json from 'rollup-plugin-json';
+import babel from 'rollup-plugin-babel';
+import resolve from 'rollup-plugin-node-resolve';
+
+export default {
+  dest: './test/utils/debugger/dist/debug.js',
+  entry: './test/utils/debugger/src/debug.js',
+  format: 'cjs',
+  banner: (
+    'require(\'source-map-support\').install({\n'
+    + '  environment: \'node\'\n'
+    + '});\n'
+  ),
+  onwarn: ({ code, message }) => {
+    if (code === 'UNUSED_EXTERNAL_IMPORT') {
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(message);
+  },
+  plugins: [
+    json(),
+    babel(),
+    resolve()
+  ],
+  external: id => !(
+    id.startsWith('.')
+    || id.startsWith('/') // Absolute path on Unix
+    || /^[A-Z]:[\\/]/.test(id) // Absolute path on Windows
+    || id.startsWith('src')
+    || id.startsWith(path.join(__dirname, 'src'))
+    || id === 'babelHelpers'
+    || id === '\u0000babelHelpers'
+  ),
+  sourceMap: true
+};

--- a/test/utils/debugger/src/debug.js
+++ b/test/utils/debugger/src/debug.js
@@ -1,0 +1,112 @@
+import childProcess from 'child_process';
+
+// @const spawn
+// Spawn commands from a node child process
+
+const { spawn } = childProcess;
+
+// @const repoDir
+// Starting CWD in the repo root
+
+const repoDir = process.cwd();
+
+// @function log
+// Shortcut for console.log
+
+function log(...msg) { console.log(...msg); }
+
+// @async runCommand
+// Run a terminal command
+
+async function runCommand(command, args = [], [ preMsg = '', successMsg = '' ]) {
+  log(preMsg);
+
+  return new Promise((resolve, reject) => {
+    const run = spawn(command, args);
+
+    run.stderr.on('data', err => {
+      log(err.toString());
+      reject(err.toString());
+    });
+
+    run.stdout.on('data', data => log(data.toString()));
+
+    run.on('exit', () => resolve(successMsg));
+
+  })
+  .then(msg => log(msg))
+  .catch(err => log(err.toString()));
+
+}
+
+// @async runInspector
+// Run the node inspector
+// and open URL in Chrome window
+
+async function runInspector() {
+  log('Starting node inspector...');
+
+  return new Promise((resolve, reject) => {
+
+    const inspectArgs = '--inspect=4000 dist/boot.js'.split(' ');
+    const run = spawn('node', inspectArgs);
+
+    let url;
+
+    function openURL(url) {
+      runCommand(
+        'osascript',
+        ['-e', `tell application "Google Chrome" to open location "${url}"`],
+        ['Opening in Google Chrome (OSX Users only)']
+      );
+    }
+
+    function parseURL(msg) {
+      msg = msg.split('chrome-devtools');
+      return `chrome-devtools${msg[1]}`.replace(/\s+/g, '');
+    }
+
+    run.stderr.on('data', msg => {
+      if (url) { return; }
+      msg = msg.toString();
+      log(msg);
+      url = parseURL(msg);
+      openURL(url);
+
+    });
+
+    run.stdout.on('data', data => log(data.toString()));
+
+    run.on('exit', (code) => log(`Child exited with code ${code}`));
+
+  })
+  .then(msg => log(msg))
+  .catch(err => log(err.toString));
+
+}
+
+// @listener
+// Ensure repoDir is returned to when process exits
+
+process.on('exit', () => {
+  process.chdir(repoDir);
+});
+
+// @async
+// Run commands
+
+(async function() {
+
+  const cleanArgs = 'rm -rf .nyc_output coverage dist test/test-app/dist test-results.xml'.split(' ');
+
+  await runCommand('shx', cleanArgs, ['Cleaning Lux repo...', 'Repo cleaned.']);
+
+  await runCommand('rollup', ['-c'], ['Building Lux source...', 'Lux source built.']);
+
+  process.chdir('./test/test-app');
+
+  await runCommand('lux', ['build'], ['Building Lux test-app...', 'Lux test-app built.']);
+
+  await runInspector();
+
+}());


### PR DESCRIPTION
I've put together a very basic Lux development debugging utility, which significantly speeds up the process of debugging the Lux source code and test application.

To use, simply run `npm run debugger` from the root of the Lux repo. 

The debugger does the following:

1. Cleans the Lux environment => `npm run clean`
2. Builds Lux source into `/dist` => `npm run build`
3. Builds the test app => `cd test/test-app && lux build`
4. Runs node inspector => `node --inspect=4000 dist/boot.js`
5. Opens the URL in Chrome (Mac only) using an osascript (node [opn](https://github.com/sindresorhus/opn) doesn't respect `chrome-devtools` URLs)