### PR TITLE
feat: expands Knex query coverage on models

### DIFF
--- a/src/packages/database/model/index.js
+++ b/src/packages/database/model/index.js
@@ -1342,6 +1342,16 @@ class Model {
     return new Query(this).where(conditions);
   }
 
+  static whereBetween(conditions: Object): Query<Array<this>> {
+    return new Query(this).whereBetween(conditions);
+  }
+
+  static whereRaw(
+    query: string,
+    bindings: Array<any> = []): Query<Array<this>> {
+    return new Query(this).whereRaw(query, bindings);
+  }
+
   static not(conditions: Object): Query<Array<this>> {
     return new Query(this).not(conditions);
   }

--- a/src/packages/database/test/model.test.js
+++ b/src/packages/database/test/model.test.js
@@ -562,6 +562,47 @@ describe('module "database/model"', () => {
       });
     });
 
+    describe('.whereBetween()', () => {
+      class Subject extends Model {
+        static tableName = 'posts';
+      }
+
+      before(async () => {
+        await Subject.initialize(store, () => {
+          return store.connection(Subject.tableName);
+        });
+      });
+
+      it('returns an instance of `Query`', () => {
+        const result = Subject.whereBetween({
+          userId: [1, 10]
+        });
+
+        expect(result).to.be.an.instanceof(Query);
+      });
+    });
+
+    describe('.whereRaw()', () => {
+      class Subject extends Model {
+        static tableName = 'posts';
+      }
+
+      before(async () => {
+        await Subject.initialize(store, () => {
+          return store.connection(Subject.tableName);
+        });
+      });
+
+      it('returns an instance of `Query`', () => {
+        const result = Subject.whereRaw(
+          `"title" LIKE ?`,
+          [`%Test%`]
+        );
+
+        expect(result).to.be.an.instanceof(Query);
+      });
+    });
+
     describe('.not()', () => {
       class Subject extends Model {
         static tableName = 'posts';

--- a/src/packages/database/test/query.test.js
+++ b/src/packages/database/test/query.test.js
@@ -407,6 +407,16 @@ describe('module "database/query"', () => {
         ]);
       });
 
+      it('properly handles null conditions', () => {
+        const result = subject.where({
+          isPublic: null
+        });
+
+        expect(result.snapshots).to.deep.equal([
+          ['whereNull', ['posts.is_public']]
+        ]);
+      });
+
       it('resolves with the correct array of `Model` instances', async () => {
         const result = await subject.where({
           isPublic: true
@@ -418,6 +428,93 @@ describe('module "database/query"', () => {
           result.forEach(item => {
             assertItem(item);
             expect(item).to.have.property('isPublic', true);
+          });
+        }
+      });
+    });
+
+    describe('#whereBetween()', () => {
+      let subject;
+
+      beforeEach(() => {
+        subject = new Query(TestModel);
+      });
+
+      it('returns `this`', () => {
+        const result = subject.whereBetween({
+          userId: [1, 10]
+        });
+
+        expect(result).to.equal(subject);
+      });
+
+      it('properly modifies #snapshots', () => {
+        const result = subject.whereBetween({
+          userId: [1, 10]
+        });
+
+        expect(result.snapshots).to.deep.equal([
+          ['whereBetween', ['posts.user_id', [1, 10]]]
+        ]);
+      });
+
+      it('resolves with the correct array of `Model` instances', async () => {
+        const result = await subject.whereBetween({
+          userId: [1, 10]
+        });
+
+        expect(result).to.be.an('array');
+
+        if (Array.isArray(result)) {
+          result.forEach(item => {
+            assertItem(item);
+            expect(item.userId).to.be.above(0).and.below(11);
+
+          });
+        }
+      });
+    });
+
+    describe('#whereRaw()', () => {
+      let subject;
+
+      beforeEach(() => {
+        subject = new Query(TestModel);
+      });
+
+      it('returns `this`', () => {
+        const result = subject.whereRaw(
+          `"title" LIKE ?`,
+          [`%Test%`]
+        );
+
+        expect(result).to.equal(subject);
+      });
+
+      it('properly modifies #snapshots', () => {
+        const result = subject.whereRaw(
+          `"title" LIKE ?`,
+          [`%Test%`]
+        );
+
+        expect(result.snapshots).to.deep.equal([
+          ['whereRaw', [`"title" LIKE ?`, [`%Test%`]]]
+        ]);
+      });
+
+      it('resolves with the correct array of `Model` instances', async () => {
+        const result = await subject.whereRaw(
+          `"title" LIKE ?`,
+          [`%Test%`]
+        );
+
+        expect(result).to.be.an('array');
+
+        if (Array.isArray(result)) {
+          result.forEach(item => {
+            assertItem(item);
+            expect(item.title).to.match(/Test/);
+
           });
         }
       });

--- a/test/test-app/db/seed.js
+++ b/test/test-app/db/seed.js
@@ -48,7 +48,7 @@ export default async function seed(trx) {
     Array.from(range(1, 100)).map(() => (
       Post.transacting(trx).create({
         body: lorem.paragraphs(),
-        title: lorem.sentence(),
+        title: `${arguments[1] === 0 ? 'Test ' : ''} ${lorem.sentence()}`,
         userId: randomize([...range(1, 100)]),
         isPublic: random.boolean()
       })


### PR DESCRIPTION
The following PR extends the coverage of Knex query methods available to Lux models.

### whereRaw
http://knexjs.org/#Builder-whereRaw
- [x] Implemented
- [x] Tests written

Enables the user to build their own `where` queries. A prime example of the added flexibility this enables is building a scope for fuzzy text searching on columns:

```js
search(request) {
  const whereRaw = Object.keys(request.params.search)
    .reduce(([query, bindings], key, i) => {
      return [
        query += `${i === 0 ? '' : 'AND'} "${key}" LIKE ?`,
        [...bindings, `%${request.params.search[key]}%`]
      ];
    }, ['', []]);

  const [query, bindings] = whereRaw;
  return this.whereRaw(query, bindings);
}
```

### whereBetween / whereNotBetween
http://knexjs.org/#Builder-whereBetween
http://knexjs.org/#Builder-whereNotBetween
- [x] Implemented
- [x] Tests written

`whereBetween` and `whereNotBetween` are implemented in the same object format as `where({})`:

```js
Model.whereBetween({
  one: [1, 5],
  two: [1, 5]
});
=> WHERE "model"."one" BETWEEN 1 AND 5 AND "model"."two" BETWEEN 1 AND 5
```

### whereNull / whereNotNull
http://knexjs.org/#Builder-whereNull
http://knexjs.org/#Builder-whereNotNull
- [x] Implemented
- [x] Tests written

`whereNull` is a slight adjustment to the `.where({})` query. It simply turns `null` values into `whereNull` or `whereNotNull` snapshots.