### PR TITLE
fix: gracefully shutdown workers instead of waiting for the timeout to pass (fixes #702)

### DIFF
--- a/src/packages/pm/cluster/index.js
+++ b/src/packages/pm/cluster/index.js
@@ -190,15 +190,19 @@ class Cluster extends EventEmitter {
     return new Promise(resolve => {
       this.workers.delete(worker);
 
-      worker.send('shutdown');
-      worker.disconnect();
-
       const timeout = setTimeout(() => worker.kill(), 5000);
+
+      worker.once('disconnect', () => {
+        worker.emit('exit');
+      });
 
       worker.once('exit', () => {
         resolve(worker);
         clearTimeout(timeout);
       });
+
+      worker.send('shutdown');
+      worker.disconnect();
     });
   }
 

--- a/src/packages/pm/cluster/index.js
+++ b/src/packages/pm/cluster/index.js
@@ -193,7 +193,7 @@ class Cluster extends EventEmitter {
       const timeout = setTimeout(() => worker.kill(), 5000);
 
       worker.once('disconnect', () => {
-        worker.emit('exit');
+        worker.kill();
       });
 
       worker.once('exit', () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue or RFC this addresses.

Contributing Guide: https://github.com/postlight/lux/blob/master/CONTRIBUTING.md
-->
Fixes #702 

I've reordered the code a bit to make sure the listeners are attached before they can happen.
