### PR TITLE
docs: additional documentation around cli generators

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -152,7 +152,7 @@ cli
 cli
   .command('g <type> <name> [attrs...]')
   .alias('generate')
-  .description('Example: lux generate model user')
+  .description('Example: lux generate model user name:string email:string admin:boolean')
   .action((type, name, attrs) => {
     exec('generate', { type, name, attrs })
       .then(exit)

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -12,6 +12,22 @@ Use the new command to create your first project.
 lux new <app-name>
 ```
 
+### Generators
+
+Lux allows you to use the CLI to generate boilerplate for the following types:
+
+- `model`
+- `controller`
+- `serializer`
+- `middleware`
+- `migration`
+- `resource`
+- `util`
+
+```bash
+lux generate <type> <name> [attrs...]
+```
+
 ### Running
 
 To run your application use the serve command.


### PR DESCRIPTION
hey there, we're giving lux a shot over @carrot and one thing that took some digging to understand was the different generators the cli had. 

to help with this:
- i've added an example of passing attributes to the CLI's example
- added some details around the different `types` you can generate within the CLI. I think this list is complete, but i'm new to the codebase so i can't be sure. 

hope this feels helpful