### PR TITLE
fix: filtering with an empty array as a value causes an error

### DIFF
--- a/src/packages/database/__tests__/query.test.js
+++ b/src/packages/database/__tests__/query.test.js
@@ -179,6 +179,32 @@ describe('module "database/query"', () => {
         ])
       })
 
+      test('properly handles array conditions with single value', () => {
+        const result = subject.not({
+          id: [1],
+          isPublic: true
+        })
+
+        expect(result.snapshots).toEqual([
+          ['whereNot', {
+            'posts.is_public': true,
+            'posts.id': 1
+          }]
+        ])
+      })
+
+      test('properly handles empty array conditions', () => {
+        const result = subject.not({
+          id: [],
+          isPublic: true
+        })
+
+        expect(result.snapshots).toEqual([
+          ['whereNotIn', ['posts.id', []]],
+          ['whereNot', { 'posts.is_public': true }]
+        ])
+      })
+
       test('resolves with the correct array of `Model` instances', async () => {
         const result = await subject.not({
           isPublic: true
@@ -392,6 +418,32 @@ describe('module "database/query"', () => {
 
         expect(result.snapshots).toEqual([
           ['whereIn', ['posts.id', [1, 2, 3]]],
+          ['where', { 'posts.is_public': true }]
+        ])
+      })
+
+      test('properly handles array conditions with single value', () => {
+        const result = subject.where({
+          id: [1],
+          isPublic: true
+        })
+
+        expect(result.snapshots).toEqual([
+          ['where', {
+            'posts.is_public': true,
+            'posts.id': 1
+          }]
+        ])
+      })
+
+      test('properly handles empty array conditions', () => {
+        const result = subject.where({
+          id: [],
+          isPublic: true
+        })
+
+        expect(result.snapshots).toEqual([
+          ['whereIn', ['posts.id', []]],
           ['where', { 'posts.is_public': true }]
         ])
       })

--- a/src/packages/database/query/index.js
+++ b/src/packages/database/query/index.js
@@ -203,7 +203,7 @@ class Query<+T: any> extends Promise {
               not ? 'whereNotIn' : 'whereIn',
               [key, value]
             ])
-          } else if(value.length === 1) {
+          } else if (value.length === 1) {
             return {
               ...obj,
               [key]: value[0]

--- a/src/packages/database/query/index.js
+++ b/src/packages/database/query/index.js
@@ -203,12 +203,12 @@ class Query<+T: any> extends Promise {
               ...obj,
               [key]: value[0]
             }
-          } else {
-            this.snapshots.push([
-              not ? 'whereNotIn' : 'whereIn',
-              [key, value]
-            ])
           }
+
+          this.snapshots.push([
+            not ? 'whereNotIn' : 'whereIn',
+            [key, value]
+          ])
         } else if (value === null) {
           this.snapshots.push([
             not ? 'whereNotNull' : 'whereNull',

--- a/src/packages/database/query/index.js
+++ b/src/packages/database/query/index.js
@@ -198,12 +198,7 @@ class Query<+T: any> extends Promise {
         }
 
         if (Array.isArray(value)) {
-          if (value.length > 1) {
-            this.snapshots.push([
-              not ? 'whereNotIn' : 'whereIn',
-              [key, value]
-            ])
-          } else if (value.length === 1) {
+          if (value.length === 1) {
             return {
               ...obj,
               [key]: value[0]

--- a/src/packages/database/query/index.js
+++ b/src/packages/database/query/index.js
@@ -203,11 +203,16 @@ class Query<+T: any> extends Promise {
               not ? 'whereNotIn' : 'whereIn',
               [key, value]
             ])
-          } else {
+          } else if(value.length === 1) {
             return {
               ...obj,
               [key]: value[0]
             }
+          } else {
+            this.snapshots.push([
+              not ? 'whereNotIn' : 'whereIn',
+              [key, value]
+            ])
           }
         } else if (value === null) {
           this.snapshots.push([


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue or RFC this addresses.

Contributing Guide: https://github.com/postlight/lux/blob/master/CONTRIBUTING.md
-->

Fixed an edge case where an empty array in a filter would result in an error.

Relevant talk in Gitter: https://github.com/postlight/lux/blob/stable/src/packages/database/query/index.js#L198-L208