### PR TITLE
fix: await PK on create before updating relationships

### DIFF
--- a/src/packages/database/relationship/utils/update-relationship.js
+++ b/src/packages/database/relationship/utils/update-relationship.js
@@ -115,7 +115,7 @@ function updateBelongsTo({
 
     Reflect.set(record, opts.foreignKey, foreignKeyValue);
 
-    if (inverseOpts && inverseOpts.type === 'hasOne' && !record.isNew) {
+    if (inverseOpts && inverseOpts.type === 'hasOne') {
       return [
         record.constructor
           .table()


### PR DESCRIPTION
In the case of a belongsTo <-> hasOne relationship Lux attempts to update/overwrite the belongsTo FK. For new records (CREATE) however, this has the side effect of (at least with postgres) not working correctly. It attempts to run the query within the CREATE transaction resulting in a `"nextval(...)"` in the query instead of the (currently nonexistent) primary key.

~~NOTE: side-effect is that duplicate ID's might occur when DB does not have a UNIQUE constraint on the FK.~~

This PR has been updated with code to restructure the `create` method of the model so it await's the insert query before updating the relationships. This way we are sure to have a valid PK (instead of the `nextval` stuff). 

NOTE: The only downside of this approach is that the relationships are not set on validation. It might be possible to set belongsTo relationships before validation, but we must not use the created query yet as that will use an invalid PK.

<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue or RFC this addresses.

Contributing Guide: https://github.com/postlight/lux/blob/master/CONTRIBUTING.md
-->
